### PR TITLE
(#12) Correct validation

### DIFF
--- a/lib/intl_phone_field.dart
+++ b/lib/intl_phone_field.dart
@@ -81,7 +81,7 @@ class _IntlPhoneFieldState extends State<IntlPhoneField> {
           .firstWhere((item) => item['code'] == widget.initialCountryCode);
     }
     validator = widget.autoValidate
-        ? (value) => value.length != 10 ? 'Invalid Mobile Number' : null
+        ? (value) => value.length > 12 ? 'Invalid Phone Number' : null
         : widget.validator;
   }
 


### PR DESCRIPTION
According to E.164, the maximum length of the "subscriber number" is 12 digits, but may be shorter. Additionally, the validation message made the assumption that a mobile number was being entered.