### PR TITLE
Update intl_phone_field.dart

### DIFF
--- a/lib/intl_phone_field.dart
+++ b/lib/intl_phone_field.dart
@@ -104,7 +104,7 @@ class _IntlPhoneFieldState extends State<IntlPhoneField> {
                     setState(() {
                       filteredCountries = countries
                           .where((country) =>
-                              country['name'].toLowerCase().contains(value))
+                              country['name'].toLowerCase().contains(value.toLowerCase()))
                           .toList();
                     });
                   },


### PR DESCRIPTION
Updated country filter code to compare lower case country name to lower case user entry. Previously if you entered a country name starting with a capital letter, the search would not find any results.