### PR TITLE
Replacing argument "child" with "builder" in showDialog function due to deprecation

### DIFF
--- a/lib/intl_phone_field.dart
+++ b/lib/intl_phone_field.dart
@@ -190,65 +190,66 @@ class _IntlPhoneFieldState extends State<IntlPhoneField> {
   Future<void> _changeCountry() async {
     filteredCountries = countries;
     await showDialog(
-      context: context,
-      useRootNavigator: false,
-      child: StatefulBuilder(
-        builder: (ctx, setState) => Dialog(
-          child: Container(
-            padding: EdgeInsets.all(10),
-            child: Column(
-              children: <Widget>[
-                TextField(
-                  decoration: InputDecoration(
-                    suffixIcon: Icon(Icons.search),
-                    labelText: widget.searchText,
-                  ),
-                  onChanged: (value) {
-                    setState(() {
-                      filteredCountries = countries
-                          .where((country) => country['name']
-                              .toLowerCase()
-                              .contains(value.toLowerCase()))
-                          .toList();
-                    });
-                  },
-                ),
-                SizedBox(height: 20),
-                Expanded(
-                  child: ListView.builder(
-                    shrinkWrap: true,
-                    itemCount: filteredCountries.length,
-                    itemBuilder: (ctx, index) => Column(
-                      children: <Widget>[
-                        ListTile(
-                          leading: Text(
-                            filteredCountries[index]['flag'],
-                            style: TextStyle(fontSize: 30),
-                          ),
-                          title: Text(
-                            filteredCountries[index]['name'],
-                            style: TextStyle(fontWeight: FontWeight.w700),
-                          ),
-                          trailing: Text(
-                            filteredCountries[index]['dial_code'],
-                            style: TextStyle(fontWeight: FontWeight.w700),
-                          ),
-                          onTap: () {
-                            _selectedCountry = filteredCountries[index];
-                            Navigator.of(context).pop();
-                          },
-                        ),
-                        Divider(thickness: 1),
-                      ],
+        context: context,
+        useRootNavigator: false,
+        builder: (BuildContext ctx) {
+          return StatefulBuilder(
+            builder: (ctx, setState) => Dialog(
+              child: Container(
+                padding: EdgeInsets.all(10),
+                child: Column(
+                  children: <Widget>[
+                    TextField(
+                      decoration: InputDecoration(
+                        suffixIcon: Icon(Icons.search),
+                        labelText: widget.searchText,
+                      ),
+                      onChanged: (value) {
+                        setState(() {
+                          filteredCountries = countries
+                              .where((country) => country['name']
+                                  .toLowerCase()
+                                  .contains(value.toLowerCase()))
+                              .toList();
+                        });
+                      },
                     ),
-                  ),
+                    SizedBox(height: 20),
+                    Expanded(
+                      child: ListView.builder(
+                        shrinkWrap: true,
+                        itemCount: filteredCountries.length,
+                        itemBuilder: (ctx, index) => Column(
+                          children: <Widget>[
+                            ListTile(
+                              leading: Text(
+                                filteredCountries[index]['flag'],
+                                style: TextStyle(fontSize: 30),
+                              ),
+                              title: Text(
+                                filteredCountries[index]['name'],
+                                style: TextStyle(fontWeight: FontWeight.w700),
+                              ),
+                              trailing: Text(
+                                filteredCountries[index]['dial_code'],
+                                style: TextStyle(fontWeight: FontWeight.w700),
+                              ),
+                              onTap: () {
+                                _selectedCountry = filteredCountries[index];
+                                Navigator.of(context).pop();
+                              },
+                            ),
+                            Divider(thickness: 1),
+                          ],
+                        ),
+                      ),
+                    ),
+                  ],
                 ),
-              ],
+              ),
             ),
-          ),
-        ),
-      ),
-    );
+          );
+        });
     setState(() {});
   }
 


### PR DESCRIPTION
Replacing argument "child" with "builder" since the "child" argument has recently been deprecated from the showDialog function. This argument was deprecated in v0.2.3.

Fixes issue number vanshg395/intl_phone_field#31.

I see that there is another pull request for fixing the same issue, but this pull request minimizes the changes to only fixing this issue. 