### PR TITLE
Added a simple feature to give users the ability to specify a callback for when a country is changed by a user

### DIFF
--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -61,6 +61,9 @@ class _MyAppState extends State<MyApp> {
                   onChanged: (phone) {
                     print(phone.completeNumber);
                   },
+                  onCountryChanged: (phone) {
+                    print('Country code changed to: ' + phone.countryCode);
+                  },
                 ),
                 SizedBox(
                   height: 10,

--- a/lib/intl_phone_field.dart
+++ b/lib/intl_phone_field.dart
@@ -24,6 +24,7 @@ class IntlPhoneField extends StatefulWidget {
   ///  * [onEditingComplete], [onSubmitted], [onSelectionChanged]:
   ///    which are more specialized input change notifications.
   final ValueChanged<PhoneNumber> onChanged;
+  final ValueChanged<PhoneNumber> onCountryChanged;
   final FormFieldValidator<String> validator;
   final bool autoValidate;
 
@@ -154,6 +155,7 @@ class IntlPhoneField extends StatefulWidget {
       this.onSubmitted,
       this.validator,
       this.onChanged,
+      this.onCountryChanged,
       this.onSaved,
       this.showDropdownIcon = true,
       this.dropdownDecoration = const BoxDecoration(),
@@ -236,6 +238,18 @@ class _IntlPhoneFieldState extends State<IntlPhoneField> {
                               ),
                               onTap: () {
                                 _selectedCountry = filteredCountries[index];
+
+                                if (widget.onCountryChanged != null) {
+                                  widget.onCountryChanged(
+                                    PhoneNumber(
+                                      countryISOCode: _selectedCountry['code'],
+                                      countryCode:
+                                          _selectedCountry['dial_code'],
+                                      number: '',
+                                    ),
+                                  );
+                                }
+
                                 Navigator.of(context).pop();
                               },
                             ),

--- a/lib/intl_phone_field.dart
+++ b/lib/intl_phone_field.dart
@@ -190,65 +190,66 @@ class _IntlPhoneFieldState extends State<IntlPhoneField> {
   Future<void> _changeCountry() async {
     filteredCountries = countries;
     await showDialog(
-      context: context,
-      useRootNavigator: false,
-      child: StatefulBuilder(
-        builder: (ctx, setState) => Dialog(
-          child: Container(
-            padding: EdgeInsets.all(10),
-            child: Column(
-              children: <Widget>[
-                TextField(
-                  decoration: InputDecoration(
-                    suffixIcon: Icon(Icons.search),
-                    labelText: widget.searchText,
-                  ),
-                  onChanged: (value) {
-                    setState(() {
-                      filteredCountries = countries
-                          .where((country) => country['name']
-                              .toLowerCase()
-                              .contains(value.toLowerCase()))
-                          .toList();
-                    });
-                  },
-                ),
-                SizedBox(height: 20),
-                Expanded(
-                  child: ListView.builder(
-                    shrinkWrap: true,
-                    itemCount: filteredCountries.length,
-                    itemBuilder: (ctx, index) => Column(
-                      children: <Widget>[
-                        ListTile(
-                          leading: Text(
-                            filteredCountries[index]['flag'],
-                            style: TextStyle(fontSize: 30),
-                          ),
-                          title: Text(
-                            filteredCountries[index]['name'],
-                            style: TextStyle(fontWeight: FontWeight.w700),
-                          ),
-                          trailing: Text(
-                            filteredCountries[index]['dial_code'],
-                            style: TextStyle(fontWeight: FontWeight.w700),
-                          ),
-                          onTap: () {
-                            _selectedCountry = filteredCountries[index];
-                            Navigator.of(context).pop();
-                          },
-                        ),
-                        Divider(thickness: 1),
-                      ],
+        context: context,
+        useRootNavigator: false,
+        builder: (BuildContext ctx) {
+          return StatefulBuilder(
+            builder: (ctx, setState) => Dialog(
+              child: Container(
+                padding: EdgeInsets.all(10),
+                child: Column(
+                  children: <Widget>[
+                    TextField(
+                      decoration: InputDecoration(
+                        suffixIcon: Icon(Icons.search),
+                        labelText: widget.searchText,
+                      ),
+                      onChanged: (value) {
+                        setState(() {
+                          filteredCountries = countries
+                              .where((country) => country['name']
+                                  .toLowerCase()
+                                  .contains(value.toLowerCase()))
+                              .toList();
+                        });
+                      },
                     ),
-                  ),
+                    SizedBox(height: 20),
+                    Expanded(
+                      child: ListView.builder(
+                        shrinkWrap: true,
+                        itemCount: filteredCountries.length,
+                        itemBuilder: (ctx, index) => Column(
+                          children: <Widget>[
+                            ListTile(
+                              leading: Text(
+                                filteredCountries[index]['flag'],
+                                style: TextStyle(fontSize: 30),
+                              ),
+                              title: Text(
+                                filteredCountries[index]['name'],
+                                style: TextStyle(fontWeight: FontWeight.w700),
+                              ),
+                              trailing: Text(
+                                filteredCountries[index]['dial_code'],
+                                style: TextStyle(fontWeight: FontWeight.w700),
+                              ),
+                              onTap: () {
+                                _selectedCountry = filteredCountries[index];
+                                Navigator.of(context).pop();
+                              },
+                            ),
+                            Divider(thickness: 1),
+                          ],
+                        ),
+                      ),
+                    ),
+                  ],
                 ),
-              ],
+              ),
             ),
-          ),
-        ),
-      ),
-    );
+          );
+        });
     setState(() {});
   }
 


### PR DESCRIPTION
This was just a quick change I made to support detecting when a user updated the country code. Currently, each time an onChange or similar callback is made, we return a new instance of the PhoneNumber class. It might be good at some point to think about persisting the instance within the class such that we don't have to create a new one each time.

Feel free to take these changes and make modifications to it or let me know if there is anything I can do to better improve this feature. Again, this was just a quick fix that I made for myself and willing to share with others.

Addresses issues: 
- vanshg395/intl_phone_field#35
- vanshg395/intl_phone_field#27
- vanshg395/intl_phone_field#23
- vanshg395/intl_phone_field#21