### PR TITLE
No named parameter 'child' for showDialog function

### DIFF
--- a/lib/intl_phone_field.dart
+++ b/lib/intl_phone_field.dart
@@ -192,7 +192,7 @@ class _IntlPhoneFieldState extends State<IntlPhoneField> {
     await showDialog(
       context: context,
       useRootNavigator: false,
-      child: StatefulBuilder(
+      builder:(context)=> StatefulBuilder(
         builder: (ctx, setState) => Dialog(
           child: Container(
             padding: EdgeInsets.all(10),


### PR DESCRIPTION
New version flutter doesn't allow named parameter 'child' for the function showDialog