### PR TITLE
Change Côte d'Ivoire phone max length

### DIFF
--- a/lib/countries.dart
+++ b/lib/countries.dart
@@ -375,7 +375,7 @@ const List<Map<String, dynamic>> countries = [
     "flag": "🇨🇮",
     "code": "CI",
     "dial_code": 225,
-    "max_length": 8
+    "max_length": 10
   },
   {
     "name": "Croatia",


### PR DESCRIPTION
Côte d'Ivoire move from 8 to 10 digits phone number on January 31st 2021.