### PR TITLE
Fix phone number max length for Argentina

### DIFF
--- a/lib/countries.dart
+++ b/lib/countries.dart
@@ -74,7 +74,7 @@ const List<Map<String, dynamic>> countries = [
     "flag": "🇦🇷",
     "code": "AR",
     "dial_code": 54,
-    "max_length": 10
+    "max_length": 12
   },
   {
     "name": "Armenia",


### PR DESCRIPTION
Argentina's phone numbers can be longer than 10 digits. In fact, any mobile number will be at least 11 digits, in the form of +54 911 33235445.
Area code can be 3 or 4 numbers long, and the rest of the number is usually 8 numbers long.