### PR TITLE
Fixed max number length for Colombia

### DIFF
--- a/lib/countries.dart
+++ b/lib/countries.dart
@@ -333,7 +333,7 @@ const List<Map<String, dynamic>> countries = [
     "flag": "🇨🇴",
     "code": "CO",
     "dial_code": 57,
-    "max_length": 0
+    "max_length": 10
   },
   {
     "name": "Comoros",


### PR DESCRIPTION
The max length for Colombia was set at 0, which throws an assertion error in the base TextFormField.