### PR TITLE
fix Portugal max_length property

### DIFF
--- a/lib/countries.dart
+++ b/lib/countries.dart
@@ -1243,7 +1243,7 @@ const List<Map<String, dynamic>> countries = [
     "flag": "🇵🇹",
     "code": "PT",
     "dial_code": 351,
-    "max_length": 1
+    "max_length": 9
   },
   {
     "name": "Puerto Rico",


### PR DESCRIPTION
Portuguese numbers have 9 digits, not 1.