### PR TITLE
asynchronously call setState() in a safe way

### DIFF
--- a/lib/intl_phone_field.dart
+++ b/lib/intl_phone_field.dart
@@ -245,13 +245,12 @@ class _IntlPhoneFieldState extends State<IntlPhoneField> {
                     labelText: widget.searchText,
                   ),
                   onChanged: (value) {
-                    setState(() {
-                      filteredCountries = _countryList
-                          .where((country) => country['name']!
-                              .toLowerCase()
-                              .contains(value.toLowerCase()))
-                          .toList();
-                    });
+                    filteredCountries = _countryList
+                      .where((country) => country['name']!
+                      .toLowerCase()
+                      .contains(value.toLowerCase()))
+                      .toList();
+                    if (this.mounted) setState(() {});
                   },
                 ),
                 SizedBox(height: 20),
@@ -303,7 +302,7 @@ class _IntlPhoneFieldState extends State<IntlPhoneField> {
         ),
       ),
     );
-    setState(() {});
+    if (this.mounted) setState(() {});
   }
 
   @override


### PR DESCRIPTION
In order to safely call setState() asynchronously, the "mounted" property of the State object (in this case, "_IntlPhoneFieldState"), needs to be validated. If mounted is not true, setState should not be called because it would result in the exception "Unhandled Exception: setState() called after dispose(), but did not call dispose method", since the widget was disposed and its state is no longer mounted.