### PR TITLE
Convert countries from List of Maps to List od Country objects.

### DIFF
--- a/lib/countries.dart
+++ b/lib/countries.dart
@@ -1,1724 +1,1739 @@
-const List<Map<String, dynamic>> countries = [
-  {
-    "name": "Afghanistan",
-    "flag": "🇦🇫",
-    "code": "AF",
-    "dial_code": 93,
-    "max_length": 9
-  },
-  {
-    "name": "Åland Islands",
-    "flag": "🇦🇽",
-    "code": "AX",
-    "dial_code": 358,
-    "max_length": 15
-  },
-  {
-    "name": "Albania",
-    "flag": "🇦🇱",
-    "code": "AL",
-    "dial_code": 355,
-    "max_length": 9
-  },
-  {
-    "name": "Algeria",
-    "flag": "🇩🇿",
-    "code": "DZ",
-    "dial_code": 213,
-    "max_length": 9
-  },
-  {
-    "name": "American Samoa",
-    "flag": "🇦🇸",
-    "code": "AS",
-    "dial_code": 1684,
-    "max_length": 7
-  },
-  {
-    "name": "Andorra",
-    "flag": "🇦🇩",
-    "code": "AD",
-    "dial_code": 376,
-    "max_length": 9
-  },
-  {
-    "name": "Angola",
-    "flag": "🇦🇴",
-    "code": "AO",
-    "dial_code": 244,
-    "max_length": 9
-  },
-  {
-    "name": "Anguilla",
-    "flag": "🇦🇮",
-    "code": "AI",
-    "dial_code": 1264,
-    "max_length": 7
-  },
-  {
-    "name": "Antarctica",
-    "flag": "🇦🇶",
-    "code": "AQ",
-    "dial_code": 672,
-    "max_length": 6
-  },
-  {
-    "name": "Antigua and Barbuda",
-    "flag": "🇦🇬",
-    "code": "AG",
-    "dial_code": 1268,
-    "max_length": 7
-  },
-  {
-    "name": "Argentina",
-    "flag": "🇦🇷",
-    "code": "AR",
-    "dial_code": 54,
-    "max_length": 12
-  },
-  {
-    "name": "Armenia",
-    "flag": "🇦🇲",
-    "code": "AM",
-    "dial_code": 374,
-    "max_length": 8
-  },
-  {
-    "name": "Aruba",
-    "flag": "🇦🇼",
-    "code": "AW",
-    "dial_code": 297,
-    "max_length": 7
-  },
-  {
-    "name": "Australia",
-    "flag": "🇦🇺",
-    "code": "AU",
-    "dial_code": 61,
-    "max_length": 15
-  },
-  {
-    "name": "Austria",
-    "flag": "🇦🇹",
-    "code": "AT",
-    "dial_code": 43,
-    "max_length": 13
-  },
-  {
-    "name": "Azerbaijan",
-    "flag": "🇦🇿",
-    "code": "AZ",
-    "dial_code": 994,
-    "max_length": 9
-  },
-  {
-    "name": "Bahamas",
-    "flag": "🇧🇸",
-    "code": "BS",
-    "dial_code": 1242,
-    "max_length": 7
-  },
-  {
-    "name": "Bahrain",
-    "flag": "🇧🇭",
-    "code": "BH",
-    "dial_code": 973,
-    "max_length": 8
-  },
-  {
-    "name": "Bangladesh",
-    "flag": "🇧🇩",
-    "code": "BD",
-    "dial_code": 880,
-    "max_length": 10
-  },
-  {
-    "name": "Barbados",
-    "flag": "🇧🇧",
-    "code": "BB",
-    "dial_code": 1246,
-    "max_length": 7
-  },
-  {
-    "name": "Belarus",
-    "flag": "🇧🇾",
-    "code": "BY",
-    "dial_code": 375,
-    "max_length": 10
-  },
-  {
-    "name": "Belgium",
-    "flag": "🇧🇪",
-    "code": "BE",
-    "dial_code": 32,
-    "max_length": 9
-  },
-  {
-    "name": "Belize",
-    "flag": "🇧🇿",
-    "code": "BZ",
-    "dial_code": 501,
-    "max_length": 7
-  },
-  {
-    "name": "Benin",
-    "flag": "🇧🇯",
-    "code": "BJ",
-    "dial_code": 229,
-    "max_length": 8
-  },
-  {
-    "name": "Bermuda",
-    "flag": "🇧🇲",
-    "code": "BM",
-    "dial_code": 1441,
-    "max_length": 7
-  },
-  {
-    "name": "Bhutan",
-    "flag": "🇧🇹",
-    "code": "BT",
-    "dial_code": 975,
-    "max_length": 8
-  },
-  {
-    "name": "Bolivia, Plurinational State of bolivia",
-    "flag": "🇧🇴",
-    "code": "BO",
-    "dial_code": 591,
-    "max_length": 8
-  },
-  {
-    "name": "Bosnia and Herzegovina",
-    "flag": "🇧🇦",
-    "code": "BA",
-    "dial_code": 387,
-    "max_length": 9
-  },
-  {
-    "name": "Botswana",
-    "flag": "🇧🇼",
-    "code": "BW",
-    "dial_code": 267,
-    "max_length": 8
-  },
-  {
-    "name": "Bouvet Island",
-    "flag": "🇧🇻",
-    "code": "BV",
-    "dial_code": 47,
-    "max_length": 15
-  },
-  {
-    "name": "Brazil",
-    "flag": "🇧🇷",
-    "code": "BR",
-    "dial_code": 55,
-    "max_length": 11
-  },
-  {
-    "name": "British Indian Ocean Territory",
-    "flag": "🇮🇴",
-    "code": "IO",
-    "dial_code": 246,
-    "max_length": 7
-  },
-  {
-    "name": "Brunei Darussalam",
-    "flag": "🇧🇳",
-    "code": "BN",
-    "dial_code": 673,
-    "max_length": 7
-  },
-  {
-    "name": "Bulgaria",
-    "flag": "🇧🇬",
-    "code": "BG",
-    "dial_code": 359,
-    "max_length": 9
-  },
-  {
-    "name": "Burkina Faso",
-    "flag": "🇧🇫",
-    "code": "BF",
-    "dial_code": 226,
-    "max_length": 8
-  },
-  {
-    "name": "Burundi",
-    "flag": "🇧🇮",
-    "code": "BI",
-    "dial_code": 257,
-    "max_length": 8
-  },
-  {
-    "name": "Cambodia",
-    "flag": "🇰🇭",
-    "code": "KH",
-    "dial_code": 855,
-    "max_length": 9
-  },
-  {
-    "name": "Cameroon",
-    "flag": "🇨🇲",
-    "code": "CM",
-    "dial_code": 237,
-    "max_length": 8
-  },
-  {
-    "name": "Canada",
-    "flag": "🇨🇦",
-    "code": "CA",
-    "dial_code": 1,
-    "max_length": 10
-  },
-  {
-    "name": "Cape Verde",
-    "flag": "🇨🇻",
-    "code": "CV",
-    "dial_code": 238,
-    "max_length": 7
-  },
-  {
-    "name": "Cayman Islands",
-    "flag": "🇰🇾",
-    "code": "KY",
-    "dial_code": 345,
-    "max_length": 7
-  },
-  {
-    "name": "Central African Republic",
-    "flag": "🇨🇫",
-    "code": "CF",
-    "dial_code": 236,
-    "max_length": 8
-  },
-  {
-    "name": "Chad",
-    "flag": "🇹🇩",
-    "code": "TD",
-    "dial_code": 235,
-    "max_length": 7
-  },
-  {
-    "name": "Chile",
-    "flag": "🇨🇱",
-    "code": "CL",
-    "dial_code": 56,
-    "max_length": 9
-  },
-  {
-    "name": "China",
-    "flag": "🇨🇳",
-    "code": "CN",
-    "dial_code": 86,
-    "max_length": 12
-  },
-  {
-    "name": "Christmas Island",
-    "flag": "🇨🇽",
-    "code": "CX",
-    "dial_code": 61,
-    "max_length": 15
-  },
-  {
-    "name": "Cocos (Keeling) Islands",
-    "flag": "🇨🇨",
-    "code": "CC",
-    "dial_code": 61,
-    "max_length": 15
-  },
-  {
-    "name": "Colombia",
-    "flag": "🇨🇴",
-    "code": "CO",
-    "dial_code": 57,
-    "max_length": 10
-  },
-  {
-    "name": "Comoros",
-    "flag": "🇰🇲",
-    "code": "KM",
-    "dial_code": 269,
-    "max_length": 7
-  },
-  {
-    "name": "Congo",
-    "flag": "🇨🇬",
-    "code": "CG",
-    "dial_code": 242,
-    "max_length": 7
-  },
-  {
-    "name": "Congo, The Democratic Republic of the Congo",
-    "flag": "🇨🇩",
-    "code": "CD",
-    "dial_code": 243,
-    "max_length": 9
-  },
-  {
-    "name": "Cook Islands",
-    "flag": "🇨🇰",
-    "code": "CK",
-    "dial_code": 682,
-    "max_length": 5
-  },
-  {
-    "name": "Costa Rica",
-    "flag": "🇨🇷",
-    "code": "CR",
-    "dial_code": 506,
-    "max_length": 8
-  },
-  {
-    "name": "Côte d'Ivoire",
-    "flag": "🇨🇮",
-    "code": "CI",
-    "dial_code": 225,
-    "max_length": 10
-  },
-  {
-    "name": "Croatia",
-    "flag": "🇭🇷",
-    "code": "HR",
-    "dial_code": 385,
-    "max_length": 12
-  },
-  {
-    "name": "Cuba",
-    "flag": "🇨🇺",
-    "code": "CU",
-    "dial_code": 53,
-    "max_length": 8
-  },
-  {
-    "name": "Cyprus",
-    "flag": "🇨🇾",
-    "code": "CY",
-    "dial_code": 357,
-    "max_length": 1
-  },
-  {
-    "name": "Czech Republic",
-    "flag": "🇨🇿",
-    "code": "CZ",
-    "dial_code": 420,
-    "max_length": 12
-  },
-  {
-    "name": "Denmark",
-    "flag": "🇩🇰",
-    "code": "DK",
-    "dial_code": 45,
-    "max_length": 8
-  },
-  {
-    "name": "Djibouti",
-    "flag": "🇩🇯",
-    "code": "DJ",
-    "dial_code": 253,
-    "max_length": 6
-  },
-  {
-    "name": "Dominica",
-    "flag": "🇩🇲",
-    "code": "DM",
-    "dial_code": 1767,
-    "max_length": 7
-  },
-  {
-    "name": "Dominican Republic",
-    "flag": "🇩🇴",
-    "code": "DO",
-    "dial_code": 1849,
-    "max_length": 12
-  },
-  {
-    "name": "Ecuador",
-    "flag": "🇪🇨",
-    "code": "EC",
-    "dial_code": 593,
-    "max_length": 8
-  },
-  {
-    "name": "Egypt",
-    "flag": "🇪🇬",
-    "code": "EG",
-    "dial_code": 20,
-    "max_length": 10
-  },
-  {
-    "name": "El Salvador",
-    "flag": "🇸🇻",
-    "code": "SV",
-    "dial_code": 503,
-    "max_length": 11
-  },
-  {
-    "name": "Equatorial Guinea",
-    "flag": "🇬🇶",
-    "code": "GQ",
-    "dial_code": 240,
-    "max_length": 6
-  },
-  {
-    "name": "Eritrea",
-    "flag": "🇪🇷",
-    "code": "ER",
-    "dial_code": 291,
-    "max_length": 7
-  },
-  {
-    "name": "Estonia",
-    "flag": "🇪🇪",
-    "code": "EE",
-    "dial_code": 372,
-    "max_length": 10
-  },
-  {
-    "name": "Ethiopia",
-    "flag": "🇪🇹",
-    "code": "ET",
-    "dial_code": 251,
-    "max_length": 9
-  },
-  {
-    "name": "Falkland Islands (Malvinas)",
-    "flag": "🇫🇰",
-    "code": "FK",
-    "dial_code": 500,
-    "max_length": 5
-  },
-  {
-    "name": "Faroe Islands",
-    "flag": "🇫🇴",
-    "code": "FO",
-    "dial_code": 298,
-    "max_length": 6
-  },
-  {
-    "name": "Fiji",
-    "flag": "🇫🇯",
-    "code": "FJ",
-    "dial_code": 679,
-    "max_length": 7
-  },
-  {
-    "name": "Finland",
-    "flag": "🇫🇮",
-    "code": "FI",
-    "dial_code": 358,
-    "max_length": 12
-  },
-  {
-    "name": "France",
-    "flag": "🇫🇷",
-    "code": "FR",
-    "dial_code": 33,
-    "max_length": 9
-  },
-  {
-    "name": "French Guiana",
-    "flag": "🇬🇫",
-    "code": "GF",
-    "dial_code": 594,
-    "max_length": 15
-  },
-  {
-    "name": "French Polynesia",
-    "flag": "🇵🇫",
-    "code": "PF",
-    "dial_code": 689,
-    "max_length": 6
-  },
-  {
-    "name": "French Southern Territories",
-    "flag": "🇹🇫",
-    "code": "TF",
-    "dial_code": 262,
-    "max_length": 15
-  },
-  {
-    "name": "Gabon",
-    "flag": "🇬🇦",
-    "code": "GA",
-    "dial_code": 241,
-    "max_length": 7
-  },
-  {
-    "name": "Gambia",
-    "flag": "🇬🇲",
-    "code": "GM",
-    "dial_code": 220,
-    "max_length": 7
-  },
-  {
-    "name": "Georgia",
-    "flag": "🇬🇪",
-    "code": "GE",
-    "dial_code": 995,
-    "max_length": 8
-  },
-  {
-    "name": "Germany",
-    "flag": "🇩🇪",
-    "code": "DE",
-    "dial_code": 49,
-    "max_length": 13
-  },
-  {
-    "name": "Ghana",
-    "flag": "🇬🇭",
-    "code": "GH",
-    "dial_code": 233,
-    "max_length": 10
-  },
-  {
-    "name": "Gibraltar",
-    "flag": "🇬🇮",
-    "code": "GI",
-    "dial_code": 350,
-    "max_length": 8
-  },
-  {
-    "name": "Greece",
-    "flag": "🇬🇷",
-    "code": "GR",
-    "dial_code": 30,
-    "max_length": 10
-  },
-  {
-    "name": "Greenland",
-    "flag": "🇬🇱",
-    "code": "GL",
-    "dial_code": 299,
-    "max_length": 6
-  },
-  {
-    "name": "Grenada",
-    "flag": "🇬🇩",
-    "code": "GD",
-    "dial_code": 1473,
-    "max_length": 7
-  },
-  {
-    "name": "Guadeloupe",
-    "flag": "🇬🇵",
-    "code": "GP",
-    "dial_code": 590,
-    "max_length": 15
-  },
-  {
-    "name": "Guam",
-    "flag": "🇬🇺",
-    "code": "GU",
-    "dial_code": 1671,
-    "max_length": 7
-  },
-  {
-    "name": "Guatemala",
-    "flag": "🇬🇹",
-    "code": "GT",
-    "dial_code": 502,
-    "max_length": 8
-  },
-  {
-    "name": "Guernsey",
-    "flag": "🇬🇬",
-    "code": "GG",
-    "dial_code": 44,
-    "max_length": 6
-  },
-  {
-    "name": "Guinea",
-    "flag": "🇬🇳",
-    "code": "GN",
-    "dial_code": 224,
-    "max_length": 8
-  },
-  {
-    "name": "Guinea-Bissau",
-    "flag": "🇬🇼",
-    "code": "GW",
-    "dial_code": 245,
-    "max_length": 7
-  },
-  {
-    "name": "Guyana",
-    "flag": "🇬🇾",
-    "code": "GY",
-    "dial_code": 592,
-    "max_length": 7
-  },
-  {
-    "name": "Haiti",
-    "flag": "🇭🇹",
-    "code": "HT",
-    "dial_code": 509,
-    "max_length": 8
-  },
-  {
-    "name": "Heard Island and Mcdonald Islands",
-    "flag": "🇭🇲",
-    "code": "HM",
-    "dial_code": 672,
-    "max_length": 15
-  },
-  {
-    "name": "Holy See (Vatican City State)",
-    "flag": "🇻🇦",
-    "code": "VA",
-    "dial_code": 379,
-    "max_length": 10
-  },
-  {
-    "name": "Honduras",
-    "flag": "🇭🇳",
-    "code": "HN",
-    "dial_code": 504,
-    "max_length": 8
-  },
-  {
-    "name": "Hong Kong",
-    "flag": "🇭🇰",
-    "code": "HK",
-    "dial_code": 852,
-    "max_length": 9
-  },
-  {
-    "name": "Hungary",
-    "flag": "🇭🇺",
-    "code": "HU",
-    "dial_code": 36,
-    "max_length": 9
-  },
-  {
-    "name": "Iceland",
-    "flag": "🇮🇸",
-    "code": "IS",
-    "dial_code": 354,
-    "max_length": 9
-  },
-  {
-    "name": "India",
-    "flag": "🇮🇳",
-    "code": "IN",
-    "dial_code": 91,
-    "max_length": 10
-  },
-  {
-    "name": "Indonesia",
-    "flag": "🇮🇩",
-    "code": "ID",
-    "dial_code": 62,
-    "max_length": 10
-  },
-  {
-    "name": "Iran, Islamic Republic of Persian Gulf",
-    "flag": "🇮🇷",
-    "code": "IR",
-    "dial_code": 98,
-    "max_length": 10
-  },
-  {
-    "name": "Iraq",
-    "flag": "🇮🇶",
-    "code": "IQ",
-    "dial_code": 964,
-    "max_length": 10
-  },
-  {
-    "name": "Ireland",
-    "flag": "🇮🇪",
-    "code": "IE",
-    "dial_code": 353,
-    "max_length": 11
-  },
-  {
-    "name": "Isle of Man",
-    "flag": "🇮🇲",
-    "code": "IM",
-    "dial_code": 44,
-    "max_length": 6
-  },
-  {
-    "name": "Israel",
-    "flag": "🇮🇱",
-    "code": "IL",
-    "dial_code": 972,
-    "max_length": 9
-  },
-  {
-    "name": "Italy",
-    "flag": "🇮🇹",
-    "code": "IT",
-    "dial_code": 39,
-    "max_length": 13
-  },
-  {
-    "name": "Jamaica",
-    "flag": "🇯🇲",
-    "code": "JM",
-    "dial_code": 1876,
-    "max_length": 7
-  },
-  {
-    "name": "Japan",
-    "flag": "🇯🇵",
-    "code": "JP",
-    "dial_code": 81,
-    "max_length": 10
-  },
-  {
-    "name": "Jersey",
-    "flag": "🇯🇪",
-    "code": "JE",
-    "dial_code": 44,
-    "max_length": 6
-  },
-  {
-    "name": "Jordan",
-    "flag": "🇯🇴",
-    "code": "JO",
-    "dial_code": 962,
-    "max_length": 9
-  },
-  {
-    "name": "Kazakhstan",
-    "flag": "🇰🇿",
-    "code": "KZ",
-    "dial_code": 7,
-    "max_length": 10
-  },
-  {
-    "name": "Kenya",
-    "flag": "🇰🇪",
-    "code": "KE",
-    "dial_code": 254,
-    "max_length": 10
-  },
-  {
-    "name": "Kiribati",
-    "flag": "🇰🇮",
-    "code": "KI",
-    "dial_code": 686,
-    "max_length": 5
-  },
-  {
-    "name": "Korea, Democratic People's Republic of Korea",
-    "flag": "🇰🇵",
-    "code": "KP",
-    "dial_code": 850,
-    "max_length": 10
-  },
-  {
-    "name": "Korea, Republic of South Korea",
-    "flag": "🇰🇷",
-    "code": "KR",
-    "dial_code": 82,
-    "max_length": 11
-  },
-  {
-    "name": "Kosovo",
-    "flag": "🇽🇰",
-    "code": "XK",
-    "dial_code": 383,
-    "max_length": 8
-  },
-  {
-    "name": "Kuwait",
-    "flag": "🇰🇼",
-    "code": "KW",
-    "dial_code": 965,
-    "max_length": 8
-  },
-  {
-    "name": "Kyrgyzstan",
-    "flag": "🇰🇬",
-    "code": "KG",
-    "dial_code": 996,
-    "max_length": 9
-  },
-  {
-    "name": "Laos",
-    "flag": "🇱🇦",
-    "code": "LA",
-    "dial_code": 856,
-    "max_length": 9
-  },
-  {
-    "name": "Latvia",
-    "flag": "🇱🇻",
-    "code": "LV",
-    "dial_code": 371,
-    "max_length": 8
-  },
-  {
-    "name": "Lebanon",
-    "flag": "🇱🇧",
-    "code": "LB",
-    "dial_code": 961,
-    "max_length": 8
-  },
-  {
-    "name": "Lesotho",
-    "flag": "🇱🇸",
-    "code": "LS",
-    "dial_code": 266,
-    "max_length": 8
-  },
-  {
-    "name": "Liberia",
-    "flag": "🇱🇷",
-    "code": "LR",
-    "dial_code": 231,
-    "max_length": 8
-  },
-  {
-    "name": "Libyan Arab Jamahiriya",
-    "flag": "🇱🇾",
-    "code": "LY",
-    "dial_code": 218,
-    "max_length": 9
-  },
-  {
-    "name": "Liechtenstein",
-    "flag": "🇱🇮",
-    "code": "LI",
-    "dial_code": 423,
-    "max_length": 9
-  },
-  {
-    "name": "Lithuania",
-    "flag": "🇱🇹",
-    "code": "LT",
-    "dial_code": 370,
-    "max_length": 8
-  },
-  {
-    "name": "Luxembourg",
-    "flag": "🇱🇺",
-    "code": "LU",
-    "dial_code": 352,
-    "max_length": 11
-  },
-  {
-    "name": "Macao",
-    "flag": "🇲🇴",
-    "code": "MO",
-    "dial_code": 853,
-    "max_length": 8
-  },
-  {
-    "name": "Macedonia",
-    "flag": "🇲🇰",
-    "code": "MK",
-    "dial_code": 389,
-    "max_length": 8
-  },
-  {
-    "name": "Madagascar",
-    "flag": "🇲🇬",
-    "code": "MG",
-    "dial_code": 261,
-    "max_length": 10
-  },
-  {
-    "name": "Malawi",
-    "flag": "🇲🇼",
-    "code": "MW",
-    "dial_code": 265,
-    "max_length": 8
-  },
-  {
-    "name": "Malaysia",
-    "flag": "🇲🇾",
-    "code": "MY",
-    "dial_code": 60,
-    "max_length": 11
-  },
-  {
-    "name": "Maldives",
-    "flag": "🇲🇻",
-    "code": "MV",
-    "dial_code": 960,
-    "max_length": 7
-  },
-  {
-    "name": "Mali",
-    "flag": "🇲🇱",
-    "code": "ML",
-    "dial_code": 223,
-    "max_length": 8
-  },
-  {
-    "name": "Malta",
-    "flag": "🇲🇹",
-    "code": "MT",
-    "dial_code": 356,
-    "max_length": 8
-  },
-  {
-    "name": "Marshall Islands",
-    "flag": "🇲🇭",
-    "code": "MH",
-    "dial_code": 692,
-    "max_length": 7
-  },
-  {
-    "name": "Martinique",
-    "flag": "🇲🇶",
-    "code": "MQ",
-    "dial_code": 596,
-    "max_length": 15
-  },
-  {
-    "name": "Mauritania",
-    "flag": "🇲🇷",
-    "code": "MR",
-    "dial_code": 222,
-    "max_length": 8
-  },
-  {
-    "name": "Mauritius",
-    "flag": "🇲🇺",
-    "code": "MU",
-    "dial_code": 230,
-    "max_length": 7
-  },
-  {
-    "name": "Mayotte",
-    "flag": "🇾🇹",
-    "code": "YT",
-    "dial_code": 262,
-    "max_length": 9
-  },
-  {
-    "name": "Mexico",
-    "flag": "🇲🇽",
-    "code": "MX",
-    "dial_code": 52,
-    "max_length": 10
-  },
-  {
-    "name": "Micronesia, Federated States of Micronesia",
-    "flag": "🇫🇲",
-    "code": "FM",
-    "dial_code": 691,
-    "max_length": 7
-  },
-  {
-    "name": "Moldova",
-    "flag": "🇲🇩",
-    "code": "MD",
-    "dial_code": 373,
-    "max_length": 8
-  },
-  {
-    "name": "Monaco",
-    "flag": "🇲🇨",
-    "code": "MC",
-    "dial_code": 377,
-    "max_length": 9
-  },
-  {
-    "name": "Mongolia",
-    "flag": "🇲🇳",
-    "code": "MN",
-    "dial_code": 976,
-    "max_length": 8
-  },
-  {
-    "name": "Montenegro",
-    "flag": "🇲🇪",
-    "code": "ME",
-    "dial_code": 382,
-    "max_length": 12
-  },
-  {
-    "name": "Montserrat",
-    "flag": "🇲🇸",
-    "code": "MS",
-    "dial_code": 1664,
-    "max_length": 7
-  },
-  {
-    "name": "Morocco",
-    "flag": "🇲🇦",
-    "code": "MA",
-    "dial_code": 212,
-    "max_length": 9
-  },
-  {
-    "name": "Mozambique",
-    "flag": "🇲🇿",
-    "code": "MZ",
-    "dial_code": 258,
-    "max_length": 9
-  },
-  {
-    "name": "Myanmar",
-    "flag": "🇲🇲",
-    "code": "MM",
-    "dial_code": 95,
-    "max_length": 9
-  },
-  {
-    "name": "Namibia",
-    "flag": "🇳🇦",
-    "code": "NA",
-    "dial_code": 264,
-    "max_length": 10
-  },
-  {
-    "name": "Nauru",
-    "flag": "🇳🇷",
-    "code": "NR",
-    "dial_code": 674,
-    "max_length": 7
-  },
-  {
-    "name": "Nepal",
-    "flag": "🇳🇵",
-    "code": "NP",
-    "dial_code": 977,
-    "max_length": 9
-  },
-  {
-    "name": "Netherlands",
-    "flag": "🇳🇱",
-    "code": "NL",
-    "dial_code": 31,
-    "max_length": 9
-  },
-  {
-    "name": "Netherlands Antilles",
-    "flag": "",
-    "code": "AN",
-    "dial_code": 599,
-    "max_length": 8
-  },
-  {
-    "name": "New Caledonia",
-    "flag": "🇳🇨",
-    "code": "NC",
-    "dial_code": 687,
-    "max_length": 6
-  },
-  {
-    "name": "New Zealand",
-    "flag": "🇳🇿",
-    "code": "NZ",
-    "dial_code": 64,
-    "max_length": 10
-  },
-  {
-    "name": "Nicaragua",
-    "flag": "🇳🇮",
-    "code": "NI",
-    "dial_code": 505,
-    "max_length": 8
-  },
-  {
-    "name": "Niger",
-    "flag": "🇳🇪",
-    "code": "NE",
-    "dial_code": 227,
-    "max_length": 8
-  },
-  {
-    "name": "Nigeria",
-    "flag": "🇳🇬",
-    "code": "NG",
-    "dial_code": 234,
-    "max_length": 10
-  },
-  {
-    "name": "Niue",
-    "flag": "🇳🇺",
-    "code": "NU",
-    "dial_code": 683,
-    "max_length": 4
-  },
-  {
-    "name": "Norfolk Island",
-    "flag": "🇳🇫",
-    "code": "NF",
-    "dial_code": 672,
-    "max_length": 15
-  },
-  {
-    "name": "Northern Mariana Islands",
-    "flag": "🇲🇵",
-    "code": "MP",
-    "dial_code": 1670,
-    "max_length": 7
-  },
-  {
-    "name": "Norway",
-    "flag": "🇳🇴",
-    "code": "NO",
-    "dial_code": 47,
-    "max_length": 8
-  },
-  {
-    "name": "Oman",
-    "flag": "🇴🇲",
-    "code": "OM",
-    "dial_code": 968,
-    "max_length": 8
-  },
-  {
-    "name": "Pakistan",
-    "flag": "🇵🇰",
-    "code": "PK",
-    "dial_code": 92,
-    "max_length": 10
-  },
-  {
-    "name": "Palau",
-    "flag": "🇵🇼",
-    "code": "PW",
-    "dial_code": 680,
-    "max_length": 7
-  },
-  {
-    "name": "Palestinian Territory, Occupied",
-    "flag": "🇵🇸",
-    "code": "PS",
-    "dial_code": 970,
-    "max_length": 9
-  },
-  {
-    "name": "Panama",
-    "flag": "🇵🇦",
-    "code": "PA",
-    "dial_code": 507,
-    "max_length": 8
-  },
-  {
-    "name": "Papua New Guinea",
-    "flag": "🇵🇬",
-    "code": "PG",
-    "dial_code": 675,
-    "max_length": 11
-  },
-  {
-    "name": "Paraguay",
-    "flag": "🇵🇾",
-    "code": "PY",
-    "dial_code": 595,
-    "max_length": 9
-  },
-  {
-    "name": "Peru",
-    "flag": "🇵🇪",
-    "code": "PE",
-    "dial_code": 51,
-    "max_length": 11
-  },
-  {
-    "name": "Philippines",
-    "flag": "🇵🇭",
-    "code": "PH",
-    "dial_code": 63,
-    "max_length": 10
-  },
-  {
-    "name": "Pitcairn",
-    "flag": "🇵🇳",
-    "code": "PN",
-    "dial_code": 64,
-    "max_length": 10
-  },
-  {
-    "name": "Poland",
-    "flag": "🇵🇱",
-    "code": "PL",
-    "dial_code": 48,
-    "max_length": 9
-  },
-  {
-    "name": "Portugal",
-    "flag": "🇵🇹",
-    "code": "PT",
-    "dial_code": 351,
-    "max_length": 9
-  },
-  {
-    "name": "Puerto Rico",
-    "flag": "🇵🇷",
-    "code": "PR",
-    "dial_code": 1939,
-    "max_length": 15
-  },
-  {
-    "name": "Qatar",
-    "flag": "🇶🇦",
-    "code": "QA",
-    "dial_code": 974,
-    "max_length": 8
-  },
-  {
-    "name": "Romania",
-    "flag": "🇷🇴",
-    "code": "RO",
-    "dial_code": 40,
-    "max_length": 9
-  },
-  {
-    "name": "Russia",
-    "flag": "🇷🇺",
-    "code": "RU",
-    "dial_code": 7,
-    "max_length": 10
-  },
-  {
-    "name": "Rwanda",
-    "flag": "🇷🇼",
-    "code": "RW",
-    "dial_code": 250,
-    "max_length": 9
-  },
-  {
-    "name": "Reunion",
-    "flag": "🇷🇪",
-    "code": "RE",
-    "dial_code": 262,
-    "max_length": 9
-  },
-  {
-    "name": "Saint Barthelemy",
-    "flag": "🇧🇱",
-    "code": "BL",
-    "dial_code": 590,
-    "max_length": 9
-  },
-  {
-    "name": "Saint Helena, Ascension and Tristan Da Cunha",
-    "flag": "🇸🇭",
-    "code": "SH",
-    "dial_code": 290,
-    "max_length": 4
-  },
-  {
-    "name": "Saint Kitts and Nevis",
-    "flag": "🇰🇳",
-    "code": "KN",
-    "dial_code": 1869,
-    "max_length": 7
-  },
-  {
-    "name": "Saint Lucia",
-    "flag": "🇱🇨",
-    "code": "LC",
-    "dial_code": 1758,
-    "max_length": 7
-  },
-  {
-    "name": "Saint Martin",
-    "flag": "🇲🇫",
-    "code": "MF",
-    "dial_code": 590,
-    "max_length": 9
-  },
-  {
-    "name": "Saint Pierre and Miquelon",
-    "flag": "🇵🇲",
-    "code": "PM",
-    "dial_code": 508,
-    "max_length": 6
-  },
-  {
-    "name": "Saint Vincent and the Grenadines",
-    "flag": "🇻🇨",
-    "code": "VC",
-    "dial_code": 1784,
-    "max_length": 7
-  },
-  {
-    "name": "Samoa",
-    "flag": "🇼🇸",
-    "code": "WS",
-    "dial_code": 685,
-    "max_length": 7
-  },
-  {
-    "name": "San Marino",
-    "flag": "🇸🇲",
-    "code": "SM",
-    "dial_code": 378,
-    "max_length": 10
-  },
-  {
-    "name": "Sao Tome and Principe",
-    "flag": "🇸🇹",
-    "code": "ST",
-    "dial_code": 239,
-    "max_length": 7
-  },
-  {
-    "name": "Saudi Arabia",
-    "flag": "🇸🇦",
-    "code": "SA",
-    "dial_code": 966,
-    "max_length": 9
-  },
-  {
-    "name": "Senegal",
-    "flag": "🇸🇳",
-    "code": "SN",
-    "dial_code": 221,
-    "max_length": 9
-  },
-  {
-    "name": "Serbia",
-    "flag": "🇷🇸",
-    "code": "RS",
-    "dial_code": 381,
-    "max_length": 12
-  },
-  {
-    "name": "Seychelles",
-    "flag": "🇸🇨",
-    "code": "SC",
-    "dial_code": 248,
-    "max_length": 6
-  },
-  {
-    "name": "Sierra Leone",
-    "flag": "🇸🇱",
-    "code": "SL",
-    "dial_code": 232,
-    "max_length": 8
-  },
-  {
-    "name": "Singapore",
-    "flag": "🇸🇬",
-    "code": "SG",
-    "dial_code": 65,
-    "max_length": 12
-  },
-  {
-    "name": "Slovakia",
-    "flag": "🇸🇰",
-    "code": "SK",
-    "dial_code": 421,
-    "max_length": 9
-  },
-  {
-    "name": "Slovenia",
-    "flag": "🇸🇮",
-    "code": "SI",
-    "dial_code": 386,
-    "max_length": 8
-  },
-  {
-    "name": "Solomon Islands",
-    "flag": "🇸🇧",
-    "code": "SB",
-    "dial_code": 677,
-    "max_length": 5
-  },
-  {
-    "name": "Somalia",
-    "flag": "🇸🇴",
-    "code": "SO",
-    "dial_code": 252,
-    "max_length": 8
-  },
-  {
-    "name": "South Africa",
-    "flag": "🇿🇦",
-    "code": "ZA",
-    "dial_code": 27,
-    "max_length": 9
-  },
-  {
-    "name": "South Sudan",
-    "flag": "🇸🇸",
-    "code": "SS",
-    "dial_code": 211,
-    "max_length": 9
-  },
-  {
-    "name": "South Georgia and the South Sandwich Islands",
-    "flag": "🇬🇸",
-    "code": "GS",
-    "dial_code": 500,
-    "max_length": 15
-  },
-  {
-    "name": "Spain",
-    "flag": "🇪🇸",
-    "code": "ES",
-    "dial_code": 34,
-    "max_length": 9
-  },
-  {
-    "name": "Sri Lanka",
-    "flag": "🇱🇰",
-    "code": "LK",
-    "dial_code": 94,
-    "max_length": 9
-  },
-  {
-    "name": "Sudan",
-    "flag": "🇸🇩",
-    "code": "SD",
-    "dial_code": 249,
-    "max_length": 9
-  },
-  {
-    "name": "Suriname",
-    "flag": "🇸🇷",
-    "code": "SR",
-    "dial_code": 597,
-    "max_length": 7
-  },
-  {
-    "name": "Svalbard and Jan Mayen",
-    "flag": "🇸🇯",
-    "code": "SJ",
-    "dial_code": 47,
-    "max_length": 8
-  },
-  {
-    "name": "Eswatini",
-    "flag": "🇸🇿",
-    "code": "SZ",
-    "dial_code": 268,
-    "max_length": 8
-  },
-  {
-    "name": "Sweden",
-    "flag": "🇸🇪",
-    "code": "SE",
-    "dial_code": 46,
-    "max_length": 13
-  },
-  {
-    "name": "Switzerland",
-    "flag": "🇨🇭",
-    "code": "CH",
-    "dial_code": 41,
-    "max_length": 12
-  },
-  {
-    "name": "Syrian Arab Republic",
-    "flag": "🇸🇾",
-    "code": "SY",
-    "dial_code": 963,
-    "max_length": 10
-  },
-  {
-    "name": "Taiwan",
-    "flag": "🇹🇼",
-    "code": "TW",
-    "dial_code": 886,
-    "max_length": 9
-  },
-  {
-    "name": "Tajikistan",
-    "flag": "🇹🇯",
-    "code": "TJ",
-    "dial_code": 992,
-    "max_length": 9
-  },
-  {
-    "name": "Tanzania, United Republic of Tanzania",
-    "flag": "🇹🇿",
-    "code": "TZ",
-    "dial_code": 255,
-    "max_length": 9
-  },
-  {
-    "name": "Thailand",
-    "flag": "🇹🇭",
-    "code": "TH",
-    "dial_code": 66,
-    "max_length": 9
-  },
-  {
-    "name": "Timor-Leste",
-    "flag": "🇹🇱",
-    "code": "TL",
-    "dial_code": 670,
-    "max_length": 7
-  },
-  {
-    "name": "Togo",
-    "flag": "🇹🇬",
-    "code": "TG",
-    "dial_code": 228,
-    "max_length": 8
-  },
-  {
-    "name": "Tokelau",
-    "flag": "🇹🇰",
-    "code": "TK",
-    "dial_code": 690,
-    "max_length": 4
-  },
-  {
-    "name": "Tonga",
-    "flag": "🇹🇴",
-    "code": "TO",
-    "dial_code": 676,
-    "max_length": 7
-  },
-  {
-    "name": "Trinidad and Tobago",
-    "flag": "🇹🇹",
-    "code": "TT",
-    "dial_code": 1868,
-    "max_length": 7
-  },
-  {
-    "name": "Tunisia",
-    "flag": "🇹🇳",
-    "code": "TN",
-    "dial_code": 216,
-    "max_length": 8
-  },
-  {
-    "name": "Turkey",
-    "flag": "🇹🇷",
-    "code": "TR",
-    "dial_code": 90,
-    "max_length": 10
-  },
-  {
-    "name": "Turkmenistan",
-    "flag": "🇹🇲",
-    "code": "TM",
-    "dial_code": 993,
-    "max_length": 8
-  },
-  {
-    "name": "Turks and Caicos Islands",
-    "flag": "🇹🇨",
-    "code": "TC",
-    "dial_code": 1649,
-    "max_length": 7
-  },
-  {
-    "name": "Tuvalu",
-    "flag": "🇹🇻",
-    "code": "TV",
-    "dial_code": 688,
-    "max_length": 6
-  },
-  {
-    "name": "Uganda",
-    "flag": "🇺🇬",
-    "code": "UG",
-    "dial_code": 256,
-    "max_length": 9
-  },
-  {
-    "name": "Ukraine",
-    "flag": "🇺🇦",
-    "code": "UA",
-    "dial_code": 380,
-    "max_length": 9
-  },
-  {
-    "name": "United Arab Emirates",
-    "flag": "🇦🇪",
-    "code": "AE",
-    "dial_code": 971,
-    "max_length": 9
-  },
-  {
-    "name": "United Kingdom",
-    "flag": "🇬🇧",
-    "code": "GB",
-    "dial_code": 44,
-    "max_length": 10
-  },
-  {
-    "name": "United States",
-    "flag": "🇺🇸",
-    "code": "US",
-    "dial_code": 1,
-    "max_length": 10
-  },
-  {
-    "name": "Uruguay",
-    "flag": "🇺🇾",
-    "code": "UY",
-    "dial_code": 598,
-    "max_length": 11
-  },
-  {
-    "name": "Uzbekistan",
-    "flag": "🇺🇿",
-    "code": "UZ",
-    "dial_code": 998,
-    "max_length": 9
-  },
-  {
-    "name": "Vanuatu",
-    "flag": "🇻🇺",
-    "code": "VU",
-    "dial_code": 678,
-    "max_length": 7
-  },
-  {
-    "name": "Venezuela, Bolivarian Republic of Venezuela",
-    "flag": "🇻🇪",
-    "code": "VE",
-    "dial_code": 58,
-    "max_length": 10
-  },
-  {
-    "name": "Vietnam",
-    "flag": "🇻🇳",
-    "code": "VN",
-    "dial_code": 84,
-    "max_length": 11
-  },
-  {
-    "name": "Virgin Islands, British",
-    "flag": "🇻🇬",
-    "code": "VG",
-    "dial_code": 1284,
-    "max_length": 7
-  },
-  {
-    "name": "Virgin Islands, U.S.",
-    "flag": "🇻🇮",
-    "code": "VI",
-    "dial_code": 1340,
-    "max_length": 7
-  },
-  {
-    "name": "Wallis and Futuna",
-    "flag": "🇼🇫",
-    "code": "WF",
-    "dial_code": 681,
-    "max_length": 6
-  },
-  {
-    "name": "Yemen",
-    "flag": "🇾🇪",
-    "code": "YE",
-    "dial_code": 967,
-    "max_length": 9
-  },
-  {
-    "name": "Zambia",
-    "flag": "🇿🇲",
-    "code": "ZM",
-    "dial_code": 260,
-    "max_length": 9
-  },
-  {
-    "name": "Zimbabwe",
-    "flag": "🇿🇼",
-    "code": "ZW",
-    "dial_code": 263,
-    "max_length": 9
-  }
+const List<Country> countries = [
+  Country(
+    name: "Afghanistan",
+    flag: "🇦🇫",
+    code: "AF",
+    dialCode: "93",
+    maxLength: 9,
+  ),
+  Country(
+    name: "Åland Islands",
+    flag: "🇦🇽",
+    code: "AX",
+    dialCode: "358",
+    maxLength: 15,
+  ),
+  Country(
+    name: "Albania",
+    flag: "🇦🇱",
+    code: "AL",
+    dialCode: "355",
+    maxLength: 9,
+  ),
+  Country(
+    name: "Algeria",
+    flag: "🇩🇿",
+    code: "DZ",
+    dialCode: "213",
+    maxLength: 9,
+  ),
+  Country(
+    name: "American Samoa",
+    flag: "🇦🇸",
+    code: "AS",
+    dialCode: "1684",
+    maxLength: 7,
+  ),
+  Country(
+    name: "Andorra",
+    flag: "🇦🇩",
+    code: "AD",
+    dialCode: "376",
+    maxLength: 9,
+  ),
+  Country(
+    name: "Angola",
+    flag: "🇦🇴",
+    code: "AO",
+    dialCode: "244",
+    maxLength: 9,
+  ),
+  Country(
+    name: "Anguilla",
+    flag: "🇦🇮",
+    code: "AI",
+    dialCode: "1264",
+    maxLength: 7,
+  ),
+  Country(
+    name: "Antarctica",
+    flag: "🇦🇶",
+    code: "AQ",
+    dialCode: "672",
+    maxLength: 6,
+  ),
+  Country(
+    name: "Antigua and Barbuda",
+    flag: "🇦🇬",
+    code: "AG",
+    dialCode: "1268",
+    maxLength: 7,
+  ),
+  Country(
+    name: "Argentina",
+    flag: "🇦🇷",
+    code: "AR",
+    dialCode: "54",
+    maxLength: 12,
+  ),
+  Country(
+    name: "Armenia",
+    flag: "🇦🇲",
+    code: "AM",
+    dialCode: "374",
+    maxLength: 8,
+  ),
+  Country(
+    name: "Aruba",
+    flag: "🇦🇼",
+    code: "AW",
+    dialCode: "297",
+    maxLength: 7,
+  ),
+  Country(
+    name: "Australia",
+    flag: "🇦🇺",
+    code: "AU",
+    dialCode: "61",
+    maxLength: 15,
+  ),
+  Country(
+    name: "Austria",
+    flag: "🇦🇹",
+    code: "AT",
+    dialCode: "43",
+    maxLength: 13,
+  ),
+  Country(
+    name: "Azerbaijan",
+    flag: "🇦🇿",
+    code: "AZ",
+    dialCode: "994",
+    maxLength: 9,
+  ),
+  Country(
+    name: "Bahamas",
+    flag: "🇧🇸",
+    code: "BS",
+    dialCode: "1242",
+    maxLength: 7,
+  ),
+  Country(
+    name: "Bahrain",
+    flag: "🇧🇭",
+    code: "BH",
+    dialCode: "973",
+    maxLength: 8,
+  ),
+  Country(
+    name: "Bangladesh",
+    flag: "🇧🇩",
+    code: "BD",
+    dialCode: "880",
+    maxLength: 10,
+  ),
+  Country(
+    name: "Barbados",
+    flag: "🇧🇧",
+    code: "BB",
+    dialCode: "1246",
+    maxLength: 7,
+  ),
+  Country(
+    name: "Belarus",
+    flag: "🇧🇾",
+    code: "BY",
+    dialCode: "375",
+    maxLength: 10,
+  ),
+  Country(
+    name: "Belgium",
+    flag: "🇧🇪",
+    code: "BE",
+    dialCode: "32",
+    maxLength: 9,
+  ),
+  Country(
+    name: "Belize",
+    flag: "🇧🇿",
+    code: "BZ",
+    dialCode: "501",
+    maxLength: 7,
+  ),
+  Country(
+    name: "Benin",
+    flag: "🇧🇯",
+    code: "BJ",
+    dialCode: "229",
+    maxLength: 8,
+  ),
+  Country(
+    name: "Bermuda",
+    flag: "🇧🇲",
+    code: "BM",
+    dialCode: "1441",
+    maxLength: 7,
+  ),
+  Country(
+    name: "Bhutan",
+    flag: "🇧🇹",
+    code: "BT",
+    dialCode: "975",
+    maxLength: 8,
+  ),
+  Country(
+    name: "Bolivia, Plurinational State of bolivia",
+    flag: "🇧🇴",
+    code: "BO",
+    dialCode: "591",
+    maxLength: 8,
+  ),
+  Country(
+    name: "Bosnia and Herzegovina",
+    flag: "🇧🇦",
+    code: "BA",
+    dialCode: "387",
+    maxLength: 9,
+  ),
+  Country(
+    name: "Botswana",
+    flag: "🇧🇼",
+    code: "BW",
+    dialCode: "267",
+    maxLength: 8,
+  ),
+  Country(
+    name: "Bouvet Island",
+    flag: "🇧🇻",
+    code: "BV",
+    dialCode: "47",
+    maxLength: 15,
+  ),
+  Country(
+    name: "Brazil",
+    flag: "🇧🇷",
+    code: "BR",
+    dialCode: "55",
+    maxLength: 11,
+  ),
+  Country(
+    name: "British Indian Ocean Territory",
+    flag: "🇮🇴",
+    code: "IO",
+    dialCode: "246",
+    maxLength: 7,
+  ),
+  Country(
+    name: "Brunei Darussalam",
+    flag: "🇧🇳",
+    code: "BN",
+    dialCode: "673",
+    maxLength: 7,
+  ),
+  Country(
+    name: "Bulgaria",
+    flag: "🇧🇬",
+    code: "BG",
+    dialCode: "359",
+    maxLength: 9,
+  ),
+  Country(
+    name: "Burkina Faso",
+    flag: "🇧🇫",
+    code: "BF",
+    dialCode: "226",
+    maxLength: 8,
+  ),
+  Country(
+    name: "Burundi",
+    flag: "🇧🇮",
+    code: "BI",
+    dialCode: "257",
+    maxLength: 8,
+  ),
+  Country(
+    name: "Cambodia",
+    flag: "🇰🇭",
+    code: "KH",
+    dialCode: "855",
+    maxLength: 9,
+  ),
+  Country(
+    name: "Cameroon",
+    flag: "🇨🇲",
+    code: "CM",
+    dialCode: "237",
+    maxLength: 8,
+  ),
+  Country(
+    name: "Canada",
+    flag: "🇨🇦",
+    code: "CA",
+    dialCode: "1",
+    maxLength: 10,
+  ),
+  Country(
+    name: "Cape Verde",
+    flag: "🇨🇻",
+    code: "CV",
+    dialCode: "238",
+    maxLength: 7,
+  ),
+  Country(
+    name: "Cayman Islands",
+    flag: "🇰🇾",
+    code: "KY",
+    dialCode: "345",
+    maxLength: 7,
+  ),
+  Country(
+    name: "Central African Republic",
+    flag: "🇨🇫",
+    code: "CF",
+    dialCode: "236",
+    maxLength: 8,
+  ),
+  Country(
+    name: "Chad",
+    flag: "🇹🇩",
+    code: "TD",
+    dialCode: "235",
+    maxLength: 7,
+  ),
+  Country(
+    name: "Chile",
+    flag: "🇨🇱",
+    code: "CL",
+    dialCode: "56",
+    maxLength: 9,
+  ),
+  Country(
+    name: "China",
+    flag: "🇨🇳",
+    code: "CN",
+    dialCode: "86",
+    maxLength: 12,
+  ),
+  Country(
+    name: "Christmas Island",
+    flag: "🇨🇽",
+    code: "CX",
+    dialCode: "61",
+    maxLength: 15,
+  ),
+  Country(
+    name: "Cocos (Keeling) Islands",
+    flag: "🇨🇨",
+    code: "CC",
+    dialCode: "61",
+    maxLength: 15,
+  ),
+  Country(
+    name: "Colombia",
+    flag: "🇨🇴",
+    code: "CO",
+    dialCode: "57",
+    maxLength: 10,
+  ),
+  Country(
+    name: "Comoros",
+    flag: "🇰🇲",
+    code: "KM",
+    dialCode: "269",
+    maxLength: 7,
+  ),
+  Country(
+    name: "Congo",
+    flag: "🇨🇬",
+    code: "CG",
+    dialCode: "242",
+    maxLength: 7,
+  ),
+  Country(
+    name: "Congo, The Democratic Republic of the Congo",
+    flag: "🇨🇩",
+    code: "CD",
+    dialCode: "243",
+    maxLength: 9,
+  ),
+  Country(
+    name: "Cook Islands",
+    flag: "🇨🇰",
+    code: "CK",
+    dialCode: "682",
+    maxLength: 5,
+  ),
+  Country(
+    name: "Costa Rica",
+    flag: "🇨🇷",
+    code: "CR",
+    dialCode: "506",
+    maxLength: 8,
+  ),
+  Country(
+    name: "Côte d'Ivoire",
+    flag: "🇨🇮",
+    code: "CI",
+    dialCode: "225",
+    maxLength: 10,
+  ),
+  Country(
+    name: "Croatia",
+    flag: "🇭🇷",
+    code: "HR",
+    dialCode: "385",
+    maxLength: 12,
+  ),
+  Country(
+    name: "Cuba",
+    flag: "🇨🇺",
+    code: "CU",
+    dialCode: "53",
+    maxLength: 8,
+  ),
+  Country(
+    name: "Cyprus",
+    flag: "🇨🇾",
+    code: "CY",
+    dialCode: "357",
+    maxLength: 1,
+  ),
+  Country(
+    name: "Czech Republic",
+    flag: "🇨🇿",
+    code: "CZ",
+    dialCode: "420",
+    maxLength: 9,
+  ),
+  Country(
+    name: "Denmark",
+    flag: "🇩🇰",
+    code: "DK",
+    dialCode: "45",
+    maxLength: 8,
+  ),
+  Country(
+    name: "Djibouti",
+    flag: "🇩🇯",
+    code: "DJ",
+    dialCode: "253",
+    maxLength: 6,
+  ),
+  Country(
+    name: "Dominica",
+    flag: "🇩🇲",
+    code: "DM",
+    dialCode: "1767",
+    maxLength: 7,
+  ),
+  Country(
+    name: "Dominican Republic",
+    flag: "🇩🇴",
+    code: "DO",
+    dialCode: "1849",
+    maxLength: 12,
+  ),
+  Country(
+    name: "Ecuador",
+    flag: "🇪🇨",
+    code: "EC",
+    dialCode: "593",
+    maxLength: 8,
+  ),
+  Country(
+    name: "Egypt",
+    flag: "🇪🇬",
+    code: "EG",
+    dialCode: "20",
+    maxLength: 10,
+  ),
+  Country(
+    name: "El Salvador",
+    flag: "🇸🇻",
+    code: "SV",
+    dialCode: "503",
+    maxLength: 11,
+  ),
+  Country(
+    name: "Equatorial Guinea",
+    flag: "🇬🇶",
+    code: "GQ",
+    dialCode: "240",
+    maxLength: 6,
+  ),
+  Country(
+    name: "Eritrea",
+    flag: "🇪🇷",
+    code: "ER",
+    dialCode: "291",
+    maxLength: 7,
+  ),
+  Country(
+    name: "Estonia",
+    flag: "🇪🇪",
+    code: "EE",
+    dialCode: "372",
+    maxLength: 10,
+  ),
+  Country(
+    name: "Ethiopia",
+    flag: "🇪🇹",
+    code: "ET",
+    dialCode: "251",
+    maxLength: 9,
+  ),
+  Country(
+    name: "Falkland Islands (Malvinas)",
+    flag: "🇫🇰",
+    code: "FK",
+    dialCode: "500",
+    maxLength: 5,
+  ),
+  Country(
+    name: "Faroe Islands",
+    flag: "🇫🇴",
+    code: "FO",
+    dialCode: "298",
+    maxLength: 6,
+  ),
+  Country(
+    name: "Fiji",
+    flag: "🇫🇯",
+    code: "FJ",
+    dialCode: "679",
+    maxLength: 7,
+  ),
+  Country(
+    name: "Finland",
+    flag: "🇫🇮",
+    code: "FI",
+    dialCode: "358",
+    maxLength: 12,
+  ),
+  Country(
+    name: "France",
+    flag: "🇫🇷",
+    code: "FR",
+    dialCode: "33",
+    maxLength: 9,
+  ),
+  Country(
+    name: "French Guiana",
+    flag: "🇬🇫",
+    code: "GF",
+    dialCode: "594",
+    maxLength: 15,
+  ),
+  Country(
+    name: "French Polynesia",
+    flag: "🇵🇫",
+    code: "PF",
+    dialCode: "689",
+    maxLength: 6,
+  ),
+  Country(
+    name: "French Southern Territories",
+    flag: "🇹🇫",
+    code: "TF",
+    dialCode: "262",
+    maxLength: 15,
+  ),
+  Country(
+    name: "Gabon",
+    flag: "🇬🇦",
+    code: "GA",
+    dialCode: "241",
+    maxLength: 7,
+  ),
+  Country(
+    name: "Gambia",
+    flag: "🇬🇲",
+    code: "GM",
+    dialCode: "220",
+    maxLength: 7,
+  ),
+  Country(
+    name: "Georgia",
+    flag: "🇬🇪",
+    code: "GE",
+    dialCode: "995",
+    maxLength: 8,
+  ),
+  Country(
+    name: "Germany",
+    flag: "🇩🇪",
+    code: "DE",
+    dialCode: "49",
+    maxLength: 13,
+  ),
+  Country(
+    name: "Ghana",
+    flag: "🇬🇭",
+    code: "GH",
+    dialCode: "233",
+    maxLength: 10,
+  ),
+  Country(
+    name: "Gibraltar",
+    flag: "🇬🇮",
+    code: "GI",
+    dialCode: "350",
+    maxLength: 8,
+  ),
+  Country(
+    name: "Greece",
+    flag: "🇬🇷",
+    code: "GR",
+    dialCode: "30",
+    maxLength: 10,
+  ),
+  Country(
+    name: "Greenland",
+    flag: "🇬🇱",
+    code: "GL",
+    dialCode: "299",
+    maxLength: 6,
+  ),
+  Country(
+    name: "Grenada",
+    flag: "🇬🇩",
+    code: "GD",
+    dialCode: "1473",
+    maxLength: 7,
+  ),
+  Country(
+    name: "Guadeloupe",
+    flag: "🇬🇵",
+    code: "GP",
+    dialCode: "590",
+    maxLength: 15,
+  ),
+  Country(
+    name: "Guam",
+    flag: "🇬🇺",
+    code: "GU",
+    dialCode: "1671",
+    maxLength: 7,
+  ),
+  Country(
+    name: "Guatemala",
+    flag: "🇬🇹",
+    code: "GT",
+    dialCode: "502",
+    maxLength: 8,
+  ),
+  Country(
+    name: "Guernsey",
+    flag: "🇬🇬",
+    code: "GG",
+    dialCode: "44",
+    maxLength: 6,
+  ),
+  Country(
+    name: "Guinea",
+    flag: "🇬🇳",
+    code: "GN",
+    dialCode: "224",
+    maxLength: 8,
+  ),
+  Country(
+    name: "Guinea-Bissau",
+    flag: "🇬🇼",
+    code: "GW",
+    dialCode: "245",
+    maxLength: 7,
+  ),
+  Country(
+    name: "Guyana",
+    flag: "🇬🇾",
+    code: "GY",
+    dialCode: "592",
+    maxLength: 7,
+  ),
+  Country(
+    name: "Haiti",
+    flag: "🇭🇹",
+    code: "HT",
+    dialCode: "509",
+    maxLength: 8,
+  ),
+  Country(
+    name: "Heard Island and Mcdonald Islands",
+    flag: "🇭🇲",
+    code: "HM",
+    dialCode: "672",
+    maxLength: 15,
+  ),
+  Country(
+    name: "Holy See (Vatican City State)",
+    flag: "🇻🇦",
+    code: "VA",
+    dialCode: "379",
+    maxLength: 10,
+  ),
+  Country(
+    name: "Honduras",
+    flag: "🇭🇳",
+    code: "HN",
+    dialCode: "504",
+    maxLength: 8,
+  ),
+  Country(
+    name: "Hong Kong",
+    flag: "🇭🇰",
+    code: "HK",
+    dialCode: "852",
+    maxLength: 9,
+  ),
+  Country(
+    name: "Hungary",
+    flag: "🇭🇺",
+    code: "HU",
+    dialCode: "36",
+    maxLength: 9,
+  ),
+  Country(
+    name: "Iceland",
+    flag: "🇮🇸",
+    code: "IS",
+    dialCode: "354",
+    maxLength: 9,
+  ),
+  Country(
+    name: "India",
+    flag: "🇮🇳",
+    code: "IN",
+    dialCode: "91",
+    maxLength: 10,
+  ),
+  Country(
+    name: "Indonesia",
+    flag: "🇮🇩",
+    code: "ID",
+    dialCode: "62",
+    maxLength: 10,
+  ),
+  Country(
+    name: "Iran, Islamic Republic of Persian Gulf",
+    flag: "🇮🇷",
+    code: "IR",
+    dialCode: "98",
+    maxLength: 10,
+  ),
+  Country(
+    name: "Iraq",
+    flag: "🇮🇶",
+    code: "IQ",
+    dialCode: "964",
+    maxLength: 10,
+  ),
+  Country(
+    name: "Ireland",
+    flag: "🇮🇪",
+    code: "IE",
+    dialCode: "353",
+    maxLength: 11,
+  ),
+  Country(
+    name: "Isle of Man",
+    flag: "🇮🇲",
+    code: "IM",
+    dialCode: "44",
+    maxLength: 6,
+  ),
+  Country(
+    name: "Israel",
+    flag: "🇮🇱",
+    code: "IL",
+    dialCode: "972",
+    maxLength: 9,
+  ),
+  Country(
+    name: "Italy",
+    flag: "🇮🇹",
+    code: "IT",
+    dialCode: "39",
+    maxLength: 13,
+  ),
+  Country(
+    name: "Jamaica",
+    flag: "🇯🇲",
+    code: "JM",
+    dialCode: "1876",
+    maxLength: 7,
+  ),
+  Country(
+    name: "Japan",
+    flag: "🇯🇵",
+    code: "JP",
+    dialCode: "81",
+    maxLength: 10,
+  ),
+  Country(
+    name: "Jersey",
+    flag: "🇯🇪",
+    code: "JE",
+    dialCode: "44",
+    maxLength: 6,
+  ),
+  Country(
+    name: "Jordan",
+    flag: "🇯🇴",
+    code: "JO",
+    dialCode: "962",
+    maxLength: 9,
+  ),
+  Country(
+    name: "Kazakhstan",
+    flag: "🇰🇿",
+    code: "KZ",
+    dialCode: "7",
+    maxLength: 10,
+  ),
+  Country(
+    name: "Kenya",
+    flag: "🇰🇪",
+    code: "KE",
+    dialCode: "254",
+    maxLength: 10,
+  ),
+  Country(
+    name: "Kiribati",
+    flag: "🇰🇮",
+    code: "KI",
+    dialCode: "686",
+    maxLength: 5,
+  ),
+  Country(
+    name: "Korea, Democratic People's Republic of Korea",
+    flag: "🇰🇵",
+    code: "KP",
+    dialCode: "850",
+    maxLength: 10,
+  ),
+  Country(
+    name: "Korea, Republic of South Korea",
+    flag: "🇰🇷",
+    code: "KR",
+    dialCode: "82",
+    maxLength: 11,
+  ),
+  Country(
+    name: "Kosovo",
+    flag: "🇽🇰",
+    code: "XK",
+    dialCode: "383",
+    maxLength: 8,
+  ),
+  Country(
+    name: "Kuwait",
+    flag: "🇰🇼",
+    code: "KW",
+    dialCode: "965",
+    maxLength: 8,
+  ),
+  Country(
+    name: "Kyrgyzstan",
+    flag: "🇰🇬",
+    code: "KG",
+    dialCode: "996",
+    maxLength: 9,
+  ),
+  Country(
+    name: "Laos",
+    flag: "🇱🇦",
+    code: "LA",
+    dialCode: "856",
+    maxLength: 9,
+  ),
+  Country(
+    name: "Latvia",
+    flag: "🇱🇻",
+    code: "LV",
+    dialCode: "371",
+    maxLength: 8,
+  ),
+  Country(
+    name: "Lebanon",
+    flag: "🇱🇧",
+    code: "LB",
+    dialCode: "961",
+    maxLength: 8,
+  ),
+  Country(
+    name: "Lesotho",
+    flag: "🇱🇸",
+    code: "LS",
+    dialCode: "266",
+    maxLength: 8,
+  ),
+  Country(
+    name: "Liberia",
+    flag: "🇱🇷",
+    code: "LR",
+    dialCode: "231",
+    maxLength: 8,
+  ),
+  Country(
+    name: "Libyan Arab Jamahiriya",
+    flag: "🇱🇾",
+    code: "LY",
+    dialCode: "218",
+    maxLength: 9,
+  ),
+  Country(
+    name: "Liechtenstein",
+    flag: "🇱🇮",
+    code: "LI",
+    dialCode: "423",
+    maxLength: 9,
+  ),
+  Country(
+    name: "Lithuania",
+    flag: "🇱🇹",
+    code: "LT",
+    dialCode: "370",
+    maxLength: 8,
+  ),
+  Country(
+    name: "Luxembourg",
+    flag: "🇱🇺",
+    code: "LU",
+    dialCode: "352",
+    maxLength: 11,
+  ),
+  Country(
+    name: "Macao",
+    flag: "🇲🇴",
+    code: "MO",
+    dialCode: "853",
+    maxLength: 8,
+  ),
+  Country(
+    name: "Macedonia",
+    flag: "🇲🇰",
+    code: "MK",
+    dialCode: "389",
+    maxLength: 8,
+  ),
+  Country(
+    name: "Madagascar",
+    flag: "🇲🇬",
+    code: "MG",
+    dialCode: "261",
+    maxLength: 10,
+  ),
+  Country(
+    name: "Malawi",
+    flag: "🇲🇼",
+    code: "MW",
+    dialCode: "265",
+    maxLength: 8,
+  ),
+  Country(
+    name: "Malaysia",
+    flag: "🇲🇾",
+    code: "MY",
+    dialCode: "60",
+    maxLength: 11,
+  ),
+  Country(
+    name: "Maldives",
+    flag: "🇲🇻",
+    code: "MV",
+    dialCode: "960",
+    maxLength: 7,
+  ),
+  Country(
+    name: "Mali",
+    flag: "🇲🇱",
+    code: "ML",
+    dialCode: "223",
+    maxLength: 8,
+  ),
+  Country(
+    name: "Malta",
+    flag: "🇲🇹",
+    code: "MT",
+    dialCode: "356",
+    maxLength: 8,
+  ),
+  Country(
+    name: "Marshall Islands",
+    flag: "🇲🇭",
+    code: "MH",
+    dialCode: "692",
+    maxLength: 7,
+  ),
+  Country(
+    name: "Martinique",
+    flag: "🇲🇶",
+    code: "MQ",
+    dialCode: "596",
+    maxLength: 15,
+  ),
+  Country(
+    name: "Mauritania",
+    flag: "🇲🇷",
+    code: "MR",
+    dialCode: "222",
+    maxLength: 8,
+  ),
+  Country(
+    name: "Mauritius",
+    flag: "🇲🇺",
+    code: "MU",
+    dialCode: "230",
+    maxLength: 7,
+  ),
+  Country(
+    name: "Mayotte",
+    flag: "🇾🇹",
+    code: "YT",
+    dialCode: "262",
+    maxLength: 9,
+  ),
+  Country(
+    name: "Mexico",
+    flag: "🇲🇽",
+    code: "MX",
+    dialCode: "52",
+    maxLength: 10,
+  ),
+  Country(
+    name: "Micronesia, Federated States of Micronesia",
+    flag: "🇫🇲",
+    code: "FM",
+    dialCode: "691",
+    maxLength: 7,
+  ),
+  Country(
+    name: "Moldova",
+    flag: "🇲🇩",
+    code: "MD",
+    dialCode: "373",
+    maxLength: 8,
+  ),
+  Country(
+    name: "Monaco",
+    flag: "🇲🇨",
+    code: "MC",
+    dialCode: "377",
+    maxLength: 9,
+  ),
+  Country(
+    name: "Mongolia",
+    flag: "🇲🇳",
+    code: "MN",
+    dialCode: "976",
+    maxLength: 8,
+  ),
+  Country(
+    name: "Montenegro",
+    flag: "🇲🇪",
+    code: "ME",
+    dialCode: "382",
+    maxLength: 12,
+  ),
+  Country(
+    name: "Montserrat",
+    flag: "🇲🇸",
+    code: "MS",
+    dialCode: "1664",
+    maxLength: 7,
+  ),
+  Country(
+    name: "Morocco",
+    flag: "🇲🇦",
+    code: "MA",
+    dialCode: "212",
+    maxLength: 9,
+  ),
+  Country(
+    name: "Mozambique",
+    flag: "🇲🇿",
+    code: "MZ",
+    dialCode: "258",
+    maxLength: 9,
+  ),
+  Country(
+    name: "Myanmar",
+    flag: "🇲🇲",
+    code: "MM",
+    dialCode: "95",
+    maxLength: 9,
+  ),
+  Country(
+    name: "Namibia",
+    flag: "🇳🇦",
+    code: "NA",
+    dialCode: "264",
+    maxLength: 10,
+  ),
+  Country(
+    name: "Nauru",
+    flag: "🇳🇷",
+    code: "NR",
+    dialCode: "674",
+    maxLength: 7,
+  ),
+  Country(
+    name: "Nepal",
+    flag: "🇳🇵",
+    code: "NP",
+    dialCode: "977",
+    maxLength: 9,
+  ),
+  Country(
+    name: "Netherlands",
+    flag: "🇳🇱",
+    code: "NL",
+    dialCode: "31",
+    maxLength: 9,
+  ),
+  Country(
+    name: "Netherlands Antilles",
+    flag: "",
+    code: "AN",
+    dialCode: "599",
+    maxLength: 8,
+  ),
+  Country(
+    name: "New Caledonia",
+    flag: "🇳🇨",
+    code: "NC",
+    dialCode: "687",
+    maxLength: 6,
+  ),
+  Country(
+    name: "New Zealand",
+    flag: "🇳🇿",
+    code: "NZ",
+    dialCode: "64",
+    maxLength: 10,
+  ),
+  Country(
+    name: "Nicaragua",
+    flag: "🇳🇮",
+    code: "NI",
+    dialCode: "505",
+    maxLength: 8,
+  ),
+  Country(
+    name: "Niger",
+    flag: "🇳🇪",
+    code: "NE",
+    dialCode: "227",
+    maxLength: 8,
+  ),
+  Country(
+    name: "Nigeria",
+    flag: "🇳🇬",
+    code: "NG",
+    dialCode: "234",
+    maxLength: 10,
+  ),
+  Country(
+    name: "Niue",
+    flag: "🇳🇺",
+    code: "NU",
+    dialCode: "683",
+    maxLength: 4,
+  ),
+  Country(
+    name: "Norfolk Island",
+    flag: "🇳🇫",
+    code: "NF",
+    dialCode: "672",
+    maxLength: 15,
+  ),
+  Country(
+    name: "Northern Mariana Islands",
+    flag: "🇲🇵",
+    code: "MP",
+    dialCode: "1670",
+    maxLength: 7,
+  ),
+  Country(
+    name: "Norway",
+    flag: "🇳🇴",
+    code: "NO",
+    dialCode: "47",
+    maxLength: 8,
+  ),
+  Country(
+    name: "Oman",
+    flag: "🇴🇲",
+    code: "OM",
+    dialCode: "968",
+    maxLength: 8,
+  ),
+  Country(
+    name: "Pakistan",
+    flag: "🇵🇰",
+    code: "PK",
+    dialCode: "92",
+    maxLength: 10,
+  ),
+  Country(
+    name: "Palau",
+    flag: "🇵🇼",
+    code: "PW",
+    dialCode: "680",
+    maxLength: 7,
+  ),
+  Country(
+    name: "Palestinian Territory, Occupied",
+    flag: "🇵🇸",
+    code: "PS",
+    dialCode: "970",
+    maxLength: 9,
+  ),
+  Country(
+    name: "Panama",
+    flag: "🇵🇦",
+    code: "PA",
+    dialCode: "507",
+    maxLength: 8,
+  ),
+  Country(
+    name: "Papua New Guinea",
+    flag: "🇵🇬",
+    code: "PG",
+    dialCode: "675",
+    maxLength: 11,
+  ),
+  Country(
+    name: "Paraguay",
+    flag: "🇵🇾",
+    code: "PY",
+    dialCode: "595",
+    maxLength: 9,
+  ),
+  Country(
+    name: "Peru",
+    flag: "🇵🇪",
+    code: "PE",
+    dialCode: "51",
+    maxLength: 11,
+  ),
+  Country(
+    name: "Philippines",
+    flag: "🇵🇭",
+    code: "PH",
+    dialCode: "63",
+    maxLength: 10,
+  ),
+  Country(
+    name: "Pitcairn",
+    flag: "🇵🇳",
+    code: "PN",
+    dialCode: "64",
+    maxLength: 10,
+  ),
+  Country(
+    name: "Poland",
+    flag: "🇵🇱",
+    code: "PL",
+    dialCode: "48",
+    maxLength: 9,
+  ),
+  Country(
+    name: "Portugal",
+    flag: "🇵🇹",
+    code: "PT",
+    dialCode: "351",
+    maxLength: 9,
+  ),
+  Country(
+    name: "Puerto Rico",
+    flag: "🇵🇷",
+    code: "PR",
+    dialCode: "1939",
+    maxLength: 15,
+  ),
+  Country(
+    name: "Qatar",
+    flag: "🇶🇦",
+    code: "QA",
+    dialCode: "974",
+    maxLength: 8,
+  ),
+  Country(
+    name: "Romania",
+    flag: "🇷🇴",
+    code: "RO",
+    dialCode: "40",
+    maxLength: 9,
+  ),
+  Country(
+    name: "Russia",
+    flag: "🇷🇺",
+    code: "RU",
+    dialCode: "7",
+    maxLength: 10,
+  ),
+  Country(
+    name: "Rwanda",
+    flag: "🇷🇼",
+    code: "RW",
+    dialCode: "250",
+    maxLength: 9,
+  ),
+  Country(
+    name: "Reunion",
+    flag: "🇷🇪",
+    code: "RE",
+    dialCode: "262",
+    maxLength: 9,
+  ),
+  Country(
+    name: "Saint Barthelemy",
+    flag: "🇧🇱",
+    code: "BL",
+    dialCode: "590",
+    maxLength: 9,
+  ),
+  Country(
+    name: "Saint Helena, Ascension and Tristan Da Cunha",
+    flag: "🇸🇭",
+    code: "SH",
+    dialCode: "290",
+    maxLength: 4,
+  ),
+  Country(
+    name: "Saint Kitts and Nevis",
+    flag: "🇰🇳",
+    code: "KN",
+    dialCode: "1869",
+    maxLength: 7,
+  ),
+  Country(
+    name: "Saint Lucia",
+    flag: "🇱🇨",
+    code: "LC",
+    dialCode: "1758",
+    maxLength: 7,
+  ),
+  Country(
+    name: "Saint Martin",
+    flag: "🇲🇫",
+    code: "MF",
+    dialCode: "590",
+    maxLength: 9,
+  ),
+  Country(
+    name: "Saint Pierre and Miquelon",
+    flag: "🇵🇲",
+    code: "PM",
+    dialCode: "508",
+    maxLength: 6,
+  ),
+  Country(
+    name: "Saint Vincent and the Grenadines",
+    flag: "🇻🇨",
+    code: "VC",
+    dialCode: "1784",
+    maxLength: 7,
+  ),
+  Country(
+    name: "Samoa",
+    flag: "🇼🇸",
+    code: "WS",
+    dialCode: "685",
+    maxLength: 7,
+  ),
+  Country(
+    name: "San Marino",
+    flag: "🇸🇲",
+    code: "SM",
+    dialCode: "378",
+    maxLength: 10,
+  ),
+  Country(
+    name: "Sao Tome and Principe",
+    flag: "🇸🇹",
+    code: "ST",
+    dialCode: "239",
+    maxLength: 7,
+  ),
+  Country(
+    name: "Saudi Arabia",
+    flag: "🇸🇦",
+    code: "SA",
+    dialCode: "966",
+    maxLength: 9,
+  ),
+  Country(
+    name: "Senegal",
+    flag: "🇸🇳",
+    code: "SN",
+    dialCode: "221",
+    maxLength: 9,
+  ),
+  Country(
+    name: "Serbia",
+    flag: "🇷🇸",
+    code: "RS",
+    dialCode: "381",
+    maxLength: 12,
+  ),
+  Country(
+    name: "Seychelles",
+    flag: "🇸🇨",
+    code: "SC",
+    dialCode: "248",
+    maxLength: 6,
+  ),
+  Country(
+    name: "Sierra Leone",
+    flag: "🇸🇱",
+    code: "SL",
+    dialCode: "232",
+    maxLength: 8,
+  ),
+  Country(
+    name: "Singapore",
+    flag: "🇸🇬",
+    code: "SG",
+    dialCode: "65",
+    maxLength: 12,
+  ),
+  Country(
+    name: "Slovakia",
+    flag: "🇸🇰",
+    code: "SK",
+    dialCode: "421",
+    maxLength: 9,
+  ),
+  Country(
+    name: "Slovenia",
+    flag: "🇸🇮",
+    code: "SI",
+    dialCode: "386",
+    maxLength: 8,
+  ),
+  Country(
+    name: "Solomon Islands",
+    flag: "🇸🇧",
+    code: "SB",
+    dialCode: "677",
+    maxLength: 5,
+  ),
+  Country(
+    name: "Somalia",
+    flag: "🇸🇴",
+    code: "SO",
+    dialCode: "252",
+    maxLength: 8,
+  ),
+  Country(
+    name: "South Africa",
+    flag: "🇿🇦",
+    code: "ZA",
+    dialCode: "27",
+    maxLength: 9,
+  ),
+  Country(
+    name: "South Sudan",
+    flag: "🇸🇸",
+    code: "SS",
+    dialCode: "211",
+    maxLength: 9,
+  ),
+  Country(
+    name: "South Georgia and the South Sandwich Islands",
+    flag: "🇬🇸",
+    code: "GS",
+    dialCode: "500",
+    maxLength: 15,
+  ),
+  Country(
+    name: "Spain",
+    flag: "🇪🇸",
+    code: "ES",
+    dialCode: "34",
+    maxLength: 9,
+  ),
+  Country(
+    name: "Sri Lanka",
+    flag: "🇱🇰",
+    code: "LK",
+    dialCode: "94",
+    maxLength: 9,
+  ),
+  Country(
+    name: "Sudan",
+    flag: "🇸🇩",
+    code: "SD",
+    dialCode: "249",
+    maxLength: 9,
+  ),
+  Country(
+    name: "Suriname",
+    flag: "🇸🇷",
+    code: "SR",
+    dialCode: "597",
+    maxLength: 7,
+  ),
+  Country(
+    name: "Svalbard and Jan Mayen",
+    flag: "🇸🇯",
+    code: "SJ",
+    dialCode: "47",
+    maxLength: 8,
+  ),
+  Country(
+    name: "Eswatini",
+    flag: "🇸🇿",
+    code: "SZ",
+    dialCode: "268",
+    maxLength: 8,
+  ),
+  Country(
+    name: "Sweden",
+    flag: "🇸🇪",
+    code: "SE",
+    dialCode: "46",
+    maxLength: 13,
+  ),
+  Country(
+    name: "Switzerland",
+    flag: "🇨🇭",
+    code: "CH",
+    dialCode: "41",
+    maxLength: 12,
+  ),
+  Country(
+    name: "Syrian Arab Republic",
+    flag: "🇸🇾",
+    code: "SY",
+    dialCode: "963",
+    maxLength: 10,
+  ),
+  Country(
+    name: "Taiwan",
+    flag: "🇹🇼",
+    code: "TW",
+    dialCode: "886",
+    maxLength: 9,
+  ),
+  Country(
+    name: "Tajikistan",
+    flag: "🇹🇯",
+    code: "TJ",
+    dialCode: "992",
+    maxLength: 9,
+  ),
+  Country(
+    name: "Tanzania, United Republic of Tanzania",
+    flag: "🇹🇿",
+    code: "TZ",
+    dialCode: "255",
+    maxLength: 9,
+  ),
+  Country(
+    name: "Thailand",
+    flag: "🇹🇭",
+    code: "TH",
+    dialCode: "66",
+    maxLength: 9,
+  ),
+  Country(
+    name: "Timor-Leste",
+    flag: "🇹🇱",
+    code: "TL",
+    dialCode: "670",
+    maxLength: 7,
+  ),
+  Country(
+    name: "Togo",
+    flag: "🇹🇬",
+    code: "TG",
+    dialCode: "228",
+    maxLength: 8,
+  ),
+  Country(
+    name: "Tokelau",
+    flag: "🇹🇰",
+    code: "TK",
+    dialCode: "690",
+    maxLength: 4,
+  ),
+  Country(
+    name: "Tonga",
+    flag: "🇹🇴",
+    code: "TO",
+    dialCode: "676",
+    maxLength: 7,
+  ),
+  Country(
+    name: "Trinidad and Tobago",
+    flag: "🇹🇹",
+    code: "TT",
+    dialCode: "1868",
+    maxLength: 7,
+  ),
+  Country(
+    name: "Tunisia",
+    flag: "🇹🇳",
+    code: "TN",
+    dialCode: "216",
+    maxLength: 8,
+  ),
+  Country(
+    name: "Turkey",
+    flag: "🇹🇷",
+    code: "TR",
+    dialCode: "90",
+    maxLength: 10,
+  ),
+  Country(
+    name: "Turkmenistan",
+    flag: "🇹🇲",
+    code: "TM",
+    dialCode: "993",
+    maxLength: 8,
+  ),
+  Country(
+    name: "Turks and Caicos Islands",
+    flag: "🇹🇨",
+    code: "TC",
+    dialCode: "1649",
+    maxLength: 7,
+  ),
+  Country(
+    name: "Tuvalu",
+    flag: "🇹🇻",
+    code: "TV",
+    dialCode: "688",
+    maxLength: 6,
+  ),
+  Country(
+    name: "Uganda",
+    flag: "🇺🇬",
+    code: "UG",
+    dialCode: "256",
+    maxLength: 9,
+  ),
+  Country(
+    name: "Ukraine",
+    flag: "🇺🇦",
+    code: "UA",
+    dialCode: "380",
+    maxLength: 9,
+  ),
+  Country(
+    name: "United Arab Emirates",
+    flag: "🇦🇪",
+    code: "AE",
+    dialCode: "971",
+    maxLength: 9,
+  ),
+  Country(
+    name: "United Kingdom",
+    flag: "🇬🇧",
+    code: "GB",
+    dialCode: "44",
+    maxLength: 10,
+  ),
+  Country(
+    name: "United States",
+    flag: "🇺🇸",
+    code: "US",
+    dialCode: "1",
+    maxLength: 10,
+  ),
+  Country(
+    name: "Uruguay",
+    flag: "🇺🇾",
+    code: "UY",
+    dialCode: "598",
+    maxLength: 11,
+  ),
+  Country(
+    name: "Uzbekistan",
+    flag: "🇺🇿",
+    code: "UZ",
+    dialCode: "998",
+    maxLength: 9,
+  ),
+  Country(
+    name: "Vanuatu",
+    flag: "🇻🇺",
+    code: "VU",
+    dialCode: "678",
+    maxLength: 7,
+  ),
+  Country(
+    name: "Venezuela, Bolivarian Republic of Venezuela",
+    flag: "🇻🇪",
+    code: "VE",
+    dialCode: "58",
+    maxLength: 10,
+  ),
+  Country(
+    name: "Vietnam",
+    flag: "🇻🇳",
+    code: "VN",
+    dialCode: "84",
+    maxLength: 11,
+  ),
+  Country(
+    name: "Virgin Islands, British",
+    flag: "🇻🇬",
+    code: "VG",
+    dialCode: "1284",
+    maxLength: 7,
+  ),
+  Country(
+    name: "Virgin Islands, U.S.",
+    flag: "🇻🇮",
+    code: "VI",
+    dialCode: "1340",
+    maxLength: 7,
+  ),
+  Country(
+    name: "Wallis and Futuna",
+    flag: "🇼🇫",
+    code: "WF",
+    dialCode: "681",
+    maxLength: 6,
+  ),
+  Country(
+    name: "Yemen",
+    flag: "🇾🇪",
+    code: "YE",
+    dialCode: "967",
+    maxLength: 9,
+  ),
+  Country(
+    name: "Zambia",
+    flag: "🇿🇲",
+    code: "ZM",
+    dialCode: "260",
+    maxLength: 9,
+  ),
+  Country(
+    name: "Zimbabwe",
+    flag: "🇿🇼",
+    code: "ZW",
+    dialCode: "263",
+    maxLength: 9,
+  ),
 ];
+
+class Country {
+  final String name;
+  final String flag;
+  final String code;
+  final String dialCode;
+  final int maxLength;
+
+  const Country(
+      {required this.name,
+      required this.flag,
+      required this.code,
+      required this.dialCode,
+      required this.maxLength});
+}

--- a/lib/phone_number.dart
+++ b/lib/phone_number.dart
@@ -1,7 +1,7 @@
 class PhoneNumber {
-  String? countryISOCode;
-  String? countryCode;
-  String? number;
+  String countryISOCode;
+  String countryCode;
+  String number;
 
   PhoneNumber({
     required this.countryISOCode,
@@ -10,6 +10,6 @@ class PhoneNumber {
   });
 
   String get completeNumber {
-    return countryCode! + number!;
+    return countryCode + number;
   }
 }


### PR DESCRIPTION
Change PhoneNumber fields to non-nullable Strings.
Pass `invalidNumberMessage` to IntlPhoneField. Parse `initialValue` to get a dialCode and a number. Move country code selector button to input field decoration. Call widget methods via `?.call()`. Fix minor design issues.

Signed-off-by: Martin Edlman <ac@an.y-co.de>