### PR TITLE
Added property to set a custom padding on flag btn

### DIFF
--- a/lib/intl_phone_field.dart
+++ b/lib/intl_phone_field.dart
@@ -168,6 +168,13 @@ class IntlPhoneField extends StatefulWidget {
 
   final Color? cursorColor;
 
+  /// The padding of the Flags Button.
+  ///
+  /// The amount of insets that are applied to the Flags Button.
+  ///
+  /// If unset, defaults to [const EdgeInsets.symmetric(vertical: 8)].
+  final EdgeInsetsGeometry flagsButtonPadding;
+
   TextInputAction? textInputAction;
 
   IntlPhoneField(
@@ -204,8 +211,9 @@ class IntlPhoneField extends StatefulWidget {
       this.autovalidateMode,
       this.showCountryFlag = true,
       this.cursorColor,
-      this.disableMaxLength = false});
-
+      this.disableMaxLength = false,
+      this.flagsButtonPadding = const EdgeInsets.symmetric(vertical: 8),
+    });
 
   @override
   _IntlPhoneFieldState createState() => _IntlPhoneFieldState();
@@ -383,7 +391,7 @@ class _IntlPhoneFieldState extends State<IntlPhoneField> {
       child: InkWell(
         borderRadius: widget.dropdownDecoration.borderRadius as BorderRadius?,
         child: Padding(
-          padding: const EdgeInsets.symmetric(vertical: 8),
+          padding: widget.flagsButtonPadding,
           child: Row(
             mainAxisAlignment: MainAxisAlignment.center,
             children: <Widget>[

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: intl_phone_field
 description: A customised Flutter TextFormField to input international phone number along with country code.
-version: 2.1.0
+version: 2.1.1
 homepage: https://github.com/vanshg395/intl_phone_field
 publish_to: none
 


### PR DESCRIPTION
I found this adittion helpful, let me explain my issue

i encountered with this layout, the flags button was centered but looked offset cause the 0/10 label was making it go down a little
![image](https://user-images.githubusercontent.com/31837239/136324190-59322472-6d8c-42ed-847d-bdadf241d752.png)

addding a custom padding helped me achieve this
```dart
 IntlPhoneField(
        flagsButtonPadding:
        const EdgeInsets.only(top: 8, bottom: 30),
        ...
```
![image](https://user-images.githubusercontent.com/31837239/136325481-64544601-5589-4210-8028-cd3d6fdf01fb.png)

hope it gets added!

