### PR TITLE
Updated countries.dart with correct Ireland length

### DIFF
--- a/lib/countries.dart
+++ b/lib/countries.dart
@@ -836,8 +836,8 @@ const List<Country> countries = [
     flag: "🇮🇪",
     code: "IE",
     dialCode: "353",
-    minLength: 11,
-    maxLength: 11,
+    minLength: 7,
+    maxLength: 9,
   ),
   Country(
     name: "Isle of Man",


### PR DESCRIPTION
As per https://en.wikipedia.org/wiki/Telephone_numbers_in_the_Republic_of_Ireland, the minimum amount of numbers after the "0" or country code should be 7, with the max 9. If it needs to be the same for both, 9 would cover the max number of valid phone numbers.

This has been tested in my own app using my phone number, among others.

@all-contributors please add @cwwalsh for code