### PR TITLE
Added dropDownMargin property

### DIFF
--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -7,7 +7,7 @@ packages:
       name: async
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.8.1"
+    version: "2.8.2"
   boolean_selector:
     dependency: transitive
     description:
@@ -21,7 +21,7 @@ packages:
       name: characters
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.0"
+    version: "1.2.0"
   charcode:
     dependency: transitive
     description:
@@ -80,7 +80,7 @@ packages:
       name: matcher
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.12.10"
+    version: "0.12.11"
   meta:
     dependency: transitive
     description:
@@ -141,7 +141,7 @@ packages:
       name: test_api
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.4.2"
+    version: "0.4.3"
   typed_data:
     dependency: transitive
     description:
@@ -155,6 +155,6 @@ packages:
       name: vector_math
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.1.0"
+    version: "2.1.1"
 sdks:
-  dart: ">=2.12.0 <3.0.0"
+  dart: ">=2.14.0 <3.0.0"

--- a/lib/intl_phone_field.dart
+++ b/lib/intl_phone_field.dart
@@ -211,6 +211,13 @@ class IntlPhoneField extends StatefulWidget {
   /// & pick dialog
   final PickerDialogStyle? pickerDialogStyle;
 
+  /// The padding of the dropdown Button.
+  ///
+  /// The amount of insets that are applied to the dropdown and the flag button.
+  ///
+  /// If unset, defaults to [EdgeInsets.zero].
+  final EdgeInsets dropDownMargin;
+
   IntlPhoneField({
     Key? key,
     this.initialCountryCode,
@@ -254,6 +261,7 @@ class IntlPhoneField extends StatefulWidget {
     this.cursorWidth = 2.0,
     this.showCursor = true,
     this.pickerDialogStyle,
+    this.dropDownMargin = EdgeInsets.zero,
   }) : super(key: key);
 
   @override
@@ -387,8 +395,10 @@ class _IntlPhoneFieldState extends State<IntlPhoneField> {
     );
   }
 
-  DecoratedBox _buildFlagsButton() {
-    return DecoratedBox(
+  Container _buildFlagsButton() {
+    return Container(
+      margin: widget.dropDownMargin,
+      child: DecoratedBox(
       decoration: widget.dropdownDecoration,
       child: InkWell(
         borderRadius: widget.dropdownDecoration.borderRadius as BorderRadius?,
@@ -430,6 +440,7 @@ class _IntlPhoneFieldState extends State<IntlPhoneField> {
         ),
         onTap: widget.enabled ? _changeCountry : null,
       ),
+    ),
     );
   }
 }

--- a/lib/intl_phone_field.dart
+++ b/lib/intl_phone_field.dart
@@ -218,8 +218,11 @@ class IntlPhoneField extends StatefulWidget {
   /// If unset, defaults to [EdgeInsets.zero].
   final EdgeInsets dropDownMargin;
 
+  final String? Function(String?)? validate;
+
   IntlPhoneField({
     Key? key,
+    this.validate,
     this.initialCountryCode,
     this.obscureText = false,
     this.textAlign = TextAlign.left,
@@ -383,7 +386,7 @@ class _IntlPhoneFieldState extends State<IntlPhoneField> {
         }
         widget.onChanged?.call(phoneNumber);
       },
-      validator: (value) => validationMessage,
+      validator: widget.validate,
       maxLength: widget.disableLengthCheck ? null : _selectedCountry.maxLength,
       keyboardType: widget.keyboardType,
       inputFormatters: widget.inputFormatters,

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -7,7 +7,7 @@ packages:
       name: async
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.8.1"
+    version: "2.8.2"
   boolean_selector:
     dependency: transitive
     description:
@@ -21,7 +21,7 @@ packages:
       name: characters
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.0"
+    version: "1.2.0"
   charcode:
     dependency: transitive
     description:
@@ -66,7 +66,7 @@ packages:
       name: matcher
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.12.10"
+    version: "0.12.11"
   meta:
     dependency: transitive
     description:
@@ -127,7 +127,7 @@ packages:
       name: test_api
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.4.2"
+    version: "0.4.3"
   typed_data:
     dependency: transitive
     description:
@@ -141,6 +141,6 @@ packages:
       name: vector_math
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.1.0"
+    version: "2.1.1"
 sdks:
-  dart: ">=2.12.0 <3.0.0"
+  dart: ">=2.14.0 <3.0.0"


### PR DESCRIPTION
## Reason
I was using the package to do this:
![photo_2022-01-27_19-21-35](https://user-images.githubusercontent.com/45833151/151410597-4077fa32-0850-4c96-82dd-d5daa7cde8cf.jpg)

But it ended to be zero-margined next to Flag button border.
![photo_2022-01-27_19-21-32](https://user-images.githubusercontent.com/45833151/151410677-e2788c33-9225-47d2-aebe-55e83833dd44.jpg)

## Updates
- Added `dropDownMargin` property
- Wrapped FlagButtons with Container.
 