### PR TITLE
Updated countries.dart with correct Iceland minLength

### DIFF
--- a/lib/countries.dart
+++ b/lib/countries.dart
@@ -796,7 +796,7 @@ const List<Country> countries = [
     flag: "🇮🇸",
     code: "IS",
     dialCode: "354",
-    minLength: 9,
+    minLength: 7,
     maxLength: 9,
   ),
   Country(


### PR DESCRIPTION
As per [https://en.wikipedia.org/wiki/Telephone_numbers_in_Iceland](https://en.wikipedia.org/wiki/Telephone_numbers_in_Iceland), the minimum number of digits after the country code should be 7, with a maximum of 9. Iceland's [National Significant Number (NSN)](https://en.wikipedia.org/wiki/List_of_mobile_telephone_prefixes_by_country#cite_note-nsn_note-2) is 7, though phone numbers starting in 3 are nine digits long. The current minimum of 9 prevents most Icelandic numbers from being entered.