### PR TITLE
Update Sweden Phone number min to be 7 

### DIFF
--- a/lib/countries.dart
+++ b/lib/countries.dart
@@ -1708,7 +1708,7 @@ const List<Country> countries = [
     flag: "🇸🇪",
     code: "SE",
     dialCode: "46",
-    minLength: 13,
+    minLength: 7,
     maxLength: 13,
   ),
   Country(


### PR DESCRIPTION
Sweden have a number range  between 7 to 13  https://en.wikipedia.org/wiki/Telephone_numbers_in_Sweden