### PR TITLE
Update Uruguay phone number minimum value to 9

### DIFF
--- a/lib/countries.dart
+++ b/lib/countries.dart
@@ -1884,8 +1884,8 @@ const List<Country> countries = [
     flag: "🇺🇾",
     code: "UY",
     dialCode: "598",
-    minLength: 11,
-    maxLength: 11,
+    minLength: 9,
+    maxLength: 9,
   ),
   Country(
     name: "Uzbekistan",


### PR DESCRIPTION
Currently, Uruguay mobile numbers have a length of 9 digits. 

https://en.wikipedia.org/wiki/Telephone_numbers_in_Uruguay (see "Mobile Telephony")