### PR TITLE
Fixed initialCountryCode functionality

### DIFF
--- a/lib/intl_phone_field.dart
+++ b/lib/intl_phone_field.dart
@@ -309,7 +309,7 @@ class _IntlPhoneFieldState extends State<IntlPhoneField> {
       number = number.substring(_selectedCountry.dialCode.length);
     } else {
       _selectedCountry = _countryList.firstWhere(
-          (item) => item.code == (widget.initialCountryCode ?? 'US'),
+          (item) => '+${item.dialCode}' == (widget.initialCountryCode ?? '+1'),
           orElse: () => _countryList.first);
     }
 


### PR DESCRIPTION
initialCountryCode field did not work.
because widget.initialCountryCode is '+1' but item.code is 'US'. So I changed item.code to '+${item.dialCode}'. Because item.dialCode is '1' (for US example) and you need to add char '+' .