### PR TITLE
Updates `completeNumber` to have proper spacing

### DIFF
--- a/lib/phone_number.dart
+++ b/lib/phone_number.dart
@@ -10,7 +10,7 @@ class PhoneNumber {
   });
 
   String get completeNumber {
-    return countryCode + number;
+    return countryCode + " " + number;
   }
 
   String toString() =>


### PR DESCRIPTION
Changes the formatting of the `completeNumber` method from:
```
+1(123) 456-7890
```
to
```
+1 (123) 456-7890
```

This looks more proper when displaying in a UI