### PR TITLE
Update Ecuador Length

### DIFF
--- a/lib/countries.dart
+++ b/lib/countries.dart
@@ -501,7 +501,7 @@ const List<Country> countries = [
     code: "EC",
     dialCode: "593",
     minLength: 8,
-    maxLength: 8,
+    maxLength: 9,
   ),
   Country(
     name: "Egypt",


### PR DESCRIPTION
The international code of Ecuador is 593 and the digits that follow after this are 8 for landlines and 9 for mobiles.

Reference: https://es.wikipedia.org/wiki/N%C3%BAmeros_de_tel%C3%A9fono_en_Ecuador