### PR TITLE
Corrected Singapore phone number length to 8

### DIFF
--- a/lib/countries.dart
+++ b/lib/countries.dart
@@ -1596,8 +1596,8 @@ const List<Country> countries = [
     flag: "🇸🇬",
     code: "SG",
     dialCode: "65",
-    minLength: 12,
-    maxLength: 12,
+    minLength: 8,
+    maxLength: 8,
   ),
   Country(
     name: "Slovakia",


### PR DESCRIPTION
SG is 8 digits (e.g., 1234-5678)