### PR TITLE
Ability to sort countries

### DIFF
--- a/lib/intl_phone_field.dart
+++ b/lib/intl_phone_field.dart
@@ -9,7 +9,7 @@ import 'package:intl_phone_field/country_picker_dialog.dart';
 import './countries.dart';
 import './phone_number.dart';
 
-typedef CompareFunction = int Function(Country a, Country b);
+typedef SortFunction = List<Country> Function(List<Country> list);
 
 class IntlPhoneField extends StatefulWidget {
   /// Whether to hide the text being edited (e.g., for passwords).
@@ -240,7 +240,7 @@ class IntlPhoneField extends StatefulWidget {
   final EdgeInsets flagsButtonMargin;
 
   /// Define sorting functions for countries list
-  final CompareFunction? sortCountries;
+  final SortFunction? sortCountries;
   
   IntlPhoneField({
     Key? key,
@@ -310,7 +310,7 @@ class _IntlPhoneFieldState extends State<IntlPhoneField> {
             .where((country) => widget.countries!.contains(country.code))
             .toList();
     if (widget.sortCountries != null) {
-      _countryList = List.from(_countryList)..sort(widget.sortCountries);
+      _countryList = widget.sortCountries(List.from(_countryList));
     }
     filteredCountries = _countryList;
     number = widget.initialValue ?? '';

--- a/lib/intl_phone_field.dart
+++ b/lib/intl_phone_field.dart
@@ -310,7 +310,7 @@ class _IntlPhoneFieldState extends State<IntlPhoneField> {
             .where((country) => widget.countries!.contains(country.code))
             .toList();
     if (widget.sortCountries != null) {
-      List.from(_countryList)..sort(widget.sortCountries);
+      _countryList = List.from(_countryList)..sort(widget.sortCountries);
     }
     filteredCountries = _countryList;
     number = widget.initialValue ?? '';

--- a/lib/intl_phone_field.dart
+++ b/lib/intl_phone_field.dart
@@ -237,6 +237,9 @@ class IntlPhoneField extends StatefulWidget {
   /// If unset, defaults to [EdgeInsets.zero].
   final EdgeInsets flagsButtonMargin;
 
+  /// Define sorting functions for countries list
+  final Function<Country, Country>? sortCountries;
+  
   IntlPhoneField({
     Key? key,
     this.initialCountryCode,
@@ -281,6 +284,7 @@ class IntlPhoneField extends StatefulWidget {
     this.showCursor = true,
     this.pickerDialogStyle,
     this.flagsButtonMargin = EdgeInsets.zero,
+    this.sortCountries,
   }) : super(key: key);
 
   @override
@@ -303,6 +307,9 @@ class _IntlPhoneFieldState extends State<IntlPhoneField> {
         : countries
             .where((country) => widget.countries!.contains(country.code))
             .toList();
+    if (widget.sortCountries != null) {
+      _countryList.sort(widget.sortCountries);
+    }
     filteredCountries = _countryList;
     number = widget.initialValue ?? '';
     if (widget.initialCountryCode == null && number.startsWith('+')) {

--- a/lib/intl_phone_field.dart
+++ b/lib/intl_phone_field.dart
@@ -310,7 +310,7 @@ class _IntlPhoneFieldState extends State<IntlPhoneField> {
             .where((country) => widget.countries!.contains(country.code))
             .toList();
     if (widget.sortCountries != null) {
-      _countryList = widget.sortCountries(List.from(_countryList));
+      _countryList = widget.sortCountries!(List.from(_countryList));
     }
     filteredCountries = _countryList;
     number = widget.initialValue ?? '';

--- a/lib/intl_phone_field.dart
+++ b/lib/intl_phone_field.dart
@@ -9,6 +9,8 @@ import 'package:intl_phone_field/country_picker_dialog.dart';
 import './countries.dart';
 import './phone_number.dart';
 
+typedef CompareFunction = int Function(Country a, Country b);
+
 class IntlPhoneField extends StatefulWidget {
   /// Whether to hide the text being edited (e.g., for passwords).
   final bool obscureText;
@@ -238,7 +240,7 @@ class IntlPhoneField extends StatefulWidget {
   final EdgeInsets flagsButtonMargin;
 
   /// Define sorting functions for countries list
-  final Function<Country, Country>? sortCountries;
+  final CompareFunction? sortCountries;
   
   IntlPhoneField({
     Key? key,

--- a/lib/intl_phone_field.dart
+++ b/lib/intl_phone_field.dart
@@ -310,7 +310,7 @@ class _IntlPhoneFieldState extends State<IntlPhoneField> {
             .where((country) => widget.countries!.contains(country.code))
             .toList();
     if (widget.sortCountries != null) {
-      _countryList.sort(widget.sortCountries);
+      List.from(_countryList)..sort(widget.sortCountries);
     }
     filteredCountries = _countryList;
     number = widget.initialValue ?? '';


### PR DESCRIPTION
Added `sortCountries` attribute which accepts list of countries. This way you can sort countries in any way you want. This is useful if you want to move commonly used countries to the top.