### PR TITLE
Updated countries.dart with correct Indonesia minLength

### DIFF
--- a/lib/countries.dart
+++ b/lib/countries.dart
@@ -812,7 +812,7 @@ const List<Country> countries = [
     flag: "🇮🇩",
     code: "ID",
     dialCode: "62",
-    minLength: 13,
+    minLength: 10,
     maxLength: 13,
   ),
   Country(


### PR DESCRIPTION
As per https://en.wikipedia.org/wiki/Telephone_numbers_in_Indonesia the minimum number of digits after the country code must be 10, with a maximum of 13.

@all-contributors please add @anggaraputrapratama for update mingLength code