### PR TITLE
Fixes Singapore length

### DIFF
--- a/lib/countries.dart
+++ b/lib/countries.dart
@@ -1596,8 +1596,8 @@ const List<Country> countries = [
     flag: "🇸🇬",
     code: "SG",
     dialCode: "65",
-    minLength: 12,
-    maxLength: 12,
+    minLength: 8,
+    maxLength: 8,
   ),
   Country(
     name: "Slovakia",


### PR DESCRIPTION
Singapore mobile number length is 8 and not 12 (as currently in the package)
reference: https://en.wikipedia.org/wiki/National_conventions_for_writing_telephone_numbers#:~:text=XXX)%20YYY%20ZZZZ.-,Singapore,there%20are%20no%20area%20codes.