### PR TITLE
fix Syrian Arab Republic phone number lenght

### DIFF
--- a/lib/countries.dart
+++ b/lib/countries.dart
@@ -1739,8 +1739,8 @@ const List<Country> countries = [
     flag: "🇸🇾",
     code: "SY",
     dialCode: "963",
-    minLength: 10,
-    maxLength: 10,
+    minLength: 9,
+    maxLength: 9,
   ),
   Country(
     name: "Taiwan",


### PR DESCRIPTION
In Syria it's either to use the number with dialCode so number will be 9 digits
or use it without dialCode so number will be 10 digits