### PR TITLE
Fix length for Peruvian phone number

### DIFF
--- a/lib/countries.dart
+++ b/lib/countries.dart
@@ -1403,8 +1403,8 @@ const List<Country> countries = [
     flag: "🇵🇪",
     code: "PE",
     dialCode: "51",
-    minLength: 11,
-    maxLength: 11,
+    minLength: 9,
+    maxLength: 9,
   ),
   Country(
     name: "Philippines",


### PR DESCRIPTION
A Peruvian cell phone number consists of 9 digits instead of 11.