### PR TITLE
fix viet nam phone

### DIFF
--- a/lib/countries.dart
+++ b/lib/countries.dart
@@ -1931,8 +1931,8 @@ const List<Country> countries = [
     flag: "🇻🇳",
     code: "VN",
     dialCode: "84",
-    minLength: 11,
-    maxLength: 11,
+    minLength: 10,
+    maxLength: 10,
   ),
   Country(
     name: "Virgin Islands, British",


### PR DESCRIPTION
The Government of Vietnam has converted the first 11 numbers to 10 numbers since 2019.
https://ict.hatinh.gov.vn/bo-tt-tt-cong-bo-chi-tiet-doi-thue-bao-11-so-thanh-10-so-cua-5-nha-mang-tu-ngay-15-9-2018-1527578326.html