### PR TITLE
Fix number of digits for Switzerland

### DIFF
--- a/lib/countries.dart
+++ b/lib/countries.dart
@@ -1732,7 +1732,7 @@ const List<Country> countries = [
     code: "CH",
     dialCode: "41",
     minLength: 9,
-    maxLength: 9,
+    maxLength: 12,
   ),
   Country(
     name: "Syrian Arab Republic",

--- a/lib/countries.dart
+++ b/lib/countries.dart
@@ -1731,8 +1731,8 @@ const List<Country> countries = [
     flag: "🇨🇭",
     code: "CH",
     dialCode: "41",
-    minLength: 12,
-    maxLength: 12,
+    minLength: 9,
+    maxLength: 9,
   ),
   Country(
     name: "Syrian Arab Republic",


### PR DESCRIPTION
Without the leading zero, switzerland has 9 digits and not 12.