### PR TITLE
Update countries.dart - For Dominican Republic

### DIFF
--- a/lib/countries.dart
+++ b/lib/countries.dart
@@ -503,9 +503,9 @@ const List<Country> countries = [
     name: "Dominican Republic",
     flag: "🇩🇴",
     code: "DO",
-    dialCode: "1849",
-    minLength: 12,
-    maxLength: 12,
+    dialCode: "1",
+    minLength: 10,
+    maxLength: 10,
   ),
   Country(
     name: "Ecuador",


### PR DESCRIPTION
Hello,
We are like USA and Canada. We have "dialCode" 829 - 809 and 849 + 7 digits like 000-0000. All phones number here are or +1809-000-0000 or +1829-000-0000 or +1849-000-0000