### PR TITLE
Disable country code selector based on disableCountryChange property

### DIFF
--- a/lib/intl_phone_field.dart
+++ b/lib/intl_phone_field.dart
@@ -243,6 +243,9 @@ class IntlPhoneField extends StatefulWidget {
   //enable the autofill hint for phone number
   final bool disableAutoFillHints;
 
+  /// Enable/Disable country change. default = true
+  final bool enableCountryChange;
+
   const IntlPhoneField({
     Key? key,
     this.initialCountryCode,
@@ -267,6 +270,7 @@ class IntlPhoneField extends StatefulWidget {
     this.onCountryChanged,
     this.onSaved,
     this.showDropdownIcon = true,
+    this.enableCountryChange = true,
     this.dropdownDecoration = const BoxDecoration(),
     this.inputFormatters,
     this.enabled = true,
@@ -444,7 +448,7 @@ class _IntlPhoneFieldState extends State<IntlPhoneField> {
         decoration: widget.dropdownDecoration,
         child: InkWell(
           borderRadius: widget.dropdownDecoration.borderRadius as BorderRadius?,
-          onTap: widget.enabled ? _changeCountry : null,
+          onTap: widget.enabled && widget.enableCountryChange ? _changeCountry : null,
           child: Padding(
             padding: widget.flagsButtonPadding,
             child: Row(


### PR DESCRIPTION
This commit adds functionality to conditionally enable or disable the country code selector in the IntlPhoneField widget based on the disableCountryChange property. When disableCountryChange is true, the country code selector is disabled.