### PR TITLE
change italy country code to 39

### DIFF
--- a/lib/countries.dart
+++ b/lib/countries.dart
@@ -3315,7 +3315,7 @@ const List<Country> countries = [
     },
     flag: "🇮🇹",
     code: "IT",
-    dialCode: "41",
+    dialCode: "39",
     minLength: 13,
     maxLength: 13,
   ),


### PR DESCRIPTION
fix based on wikipedia: https://en.wikipedia.org/wiki/Telephone_numbers_in_Italy#:~:text=The%20country%20code%20for%20calling,standard%20in%20most%20European%20countries.