### PR TITLE
fix issue of no custom validation without interaction

### DIFF
--- a/lib/intl_phone_field.dart
+++ b/lib/intl_phone_field.dart
@@ -328,22 +328,20 @@ class _IntlPhoneFieldState extends State<IntlPhoneField> {
       }
     }
 
-    if (widget.autovalidateMode == AutovalidateMode.always) {
-      final initialPhoneNumber = PhoneNumber(
-        countryISOCode: _selectedCountry.code,
-        countryCode: '+${_selectedCountry.dialCode}',
-        number: widget.initialValue ?? '',
-      );
+    final initialPhoneNumber = PhoneNumber(
+      countryISOCode: _selectedCountry.code,
+      countryCode: '+${_selectedCountry.dialCode}',
+      number: widget.initialValue ?? '',
+    );
 
-      final value = widget.validator?.call(initialPhoneNumber);
+    final value = widget.validator?.call(initialPhoneNumber);
 
-      if (value is String) {
-        validatorMessage = value;
-      } else {
-        (value as Future).then((msg) {
-          validatorMessage = msg;
-        });
-      }
+    if (value is String) {
+      validatorMessage = value;
+    } else {
+      (value as Future).then((msg) {
+        validatorMessage = msg;
+      });
     }
   }
 

--- a/lib/intl_phone_field.dart
+++ b/lib/intl_phone_field.dart
@@ -336,7 +336,9 @@ class _IntlPhoneFieldState extends State<IntlPhoneField> {
 
     final value = widget.validator?.call(initialPhoneNumber);
 
-    if (value is String) {
+    if (value == null) {
+      validatorMessage = null;
+    } else if (value is String) {
       validatorMessage = value;
     } else {
       (value as Future).then((msg) {


### PR DESCRIPTION
this PR is to fix the bug mentioned in [Issue #292](https://github.com/vanshg395/intl_phone_field/issues/292). 
It removes the condition that checks if autovalidate mode is set to always before initializing value and validatorMessage.