### PR TITLE
Edits isValidNumber to return false instead of throw Exception

### DIFF
--- a/lib/phone_number.dart
+++ b/lib/phone_number.dart
@@ -43,11 +43,11 @@ class PhoneNumber {
   bool isValidNumber() {
     Country country = getCountry(completeNumber);
     if (number.length < country.minLength) {
-      throw NumberTooShortException();
+      return false;
     }
 
     if (number.length > country.maxLength) {
-      throw NumberTooLongException();
+      return false;
     }
     return true;
   }


### PR DESCRIPTION
PhoneNumber.isValidNumber() should return false instead of throw an Exception.
The caller expects a boolean value. In the event that the phone number is too short or too long then this should return false.