### PR TITLE
Update the Length of Malaysia PhoneNumber

### DIFF
--- a/lib/countries.dart
+++ b/lib/countries.dart
@@ -4091,8 +4091,8 @@ const List<Country> countries = [
     flag: "🇲🇾",
     code: "MY",
     dialCode: "60",
-    minLength: 11,
-    maxLength: 11,
+    minLength: 9,
+    maxLength: 10,
   ),
   Country(
     name: "Maldives",


### PR DESCRIPTION
As a Malaysian citizen and developer, I've made updates to the international phone field for **Malaysia**. 
In Malaysia, phone numbers have the following format: 
`Phone Key: (+60)`
phone number length of 9 digits following the phone key (`+60 123456789`). 

I've adjusted the
- `MinLength` from **11** to **9**
- `MaxLength` from **11** to **10**. 

This change aligns with the new phone number format provided by our updated phone number provider, which now includes numbers like `+60 1123456789.`