### PR TITLE
Adjusting the minLength for Brazil numbers

### DIFF
--- a/lib/countries.dart
+++ b/lib/countries.dart
@@ -960,7 +960,7 @@ const List<Country> countries = [
     flag: "🇧🇷",
     code: "BR",
     dialCode: "55",
-    minLength: 11,
+    minLength: 10,
     maxLength: 11,
   ),
   Country(


### PR DESCRIPTION
Adjusting the minimum number of digits for Brazil, because there are numbers that contain 10 digits.
Mobile phones have changed to 11 digits, but there are still home phones that contain 10 digits

@all-contributors please add @adilsonjuniordev for code