### PR TITLE
Update country_picker_dialog.dart

### DIFF
--- a/lib/country_picker_dialog.dart
+++ b/lib/country_picker_dialog.dart
@@ -136,7 +136,8 @@ class _CountryPickerDialogState extends State<CountryPickerDialog> {
                         style: widget.style?.countryNameStyle ?? const TextStyle(fontWeight: FontWeight.w700),
                       ),
                       trailing: Text(
-                        '+${_filteredCountries[index].dialCode}',
+                        Localizations.localeOf(context)=='en'?'+${_filteredCountries[index].dialCode}':'${_filteredCountries[index].dialCode}+',
+                        textDirection: Localizations.localeOf(context)=='en'?TextDirection.ltr:TextDirection.rtl,
                         style: widget.style?.countryCodeStyle ?? const TextStyle(fontWeight: FontWeight.w700),
                       ),
                       onTap: () {


### PR DESCRIPTION
Plus direction fix

Make the plus sign in the left in all languages.