### PR TITLE
Update Belarus country phone minLength

### DIFF
--- a/lib/countries.dart
+++ b/lib/countries.dart
@@ -650,7 +650,7 @@ const List<Country> countries = [
     flag: "🇧🇾",
     code: "BY",
     dialCode: "375",
-    minLength: 10,
+    minLength: 9,
     maxLength: 10,
   ),
   Country(


### PR DESCRIPTION
Belarus phone number could be 9 number long

https://en.wikipedia.org/wiki/Telephone_numbers_in_Belarus