### PR TITLE
Fix languageCode mismatched issue

### DIFF
--- a/lib/intl_phone_field.dart
+++ b/lib/intl_phone_field.dart
@@ -362,7 +362,7 @@ class _IntlPhoneFieldState extends State<IntlPhoneField> {
       useRootNavigator: false,
       builder: (context) => StatefulBuilder(
         builder: (ctx, setState) => CountryPickerDialog(
-          languageCode: widget.languageCode.toLowerCase(),
+          languageCode: widget.languageCode,
           style: widget.pickerDialogStyle,
           filteredCountries: filteredCountries,
           searchText: widget.searchText,


### PR DESCRIPTION
Fix language code mismatch issue due to the `key` of `languageCode` being converted to lowercase before use.

in the file  [lib/countries.dart](https://github.com/vanshg395/intl_phone_field/blob/master/lib/countries.dart) all keys containing capital letters were affected under `nameTranslations`:
```json
      "pt_BR": "Afeganistão",
      "sr-Cyrl": "Авганистан",
      "sr-Latn": "Avganistan",
      "zh_TW": "阿富汗",

```