### PR TITLE
Update phone number length for Congo-Brazzaville

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,23 +1,4 @@
-# International Phone Field Package
-
-[![pub package](https://img.shields.io/pub/v/intl_phone_field.svg)](https://pub.dev/packages/intl_phone_field)
-[![CI](https://github.com/vanshg395/intl_phone_field/actions/workflows/ci.yml/badge.svg?branch=master)](https://github.com/vanshg395/intl_phone_field/actions/workflows/ci.yml)
-[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
-
-A customised Flutter TextFormField to input international phone number along with country code.
-
-This widget can be used to make customised text field to take phone number input for any country along with an option to choose country code from a dropdown.
-
-## ⚠️ The package is deprecated and this repository is no longer maintained ⚠️
-
-As of June 2021, I, @marcaureln, have been maintaining this Flutter package initially created by @vanshg395. Regrettably, Vansh has been unresponsive, and I am unable to release new versions (the last release is 6 months old as of writing).
-
-Considering this, I recommend users to explore alternatives on [pub.dev](https://pub.dev/) or, if interested, fork this repository for continued support. Life can be hectic, and I wish Vansh is doing well.
-
-Thank you for your understanding and continued support.
-
-<details>
-  <summary>Old Readme</summary>
+# International  Field Phone Package New Version
 
 ## Screenshots
 

--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -7,6 +7,9 @@
 
 # The following line activates a set of recommended lints for Flutter apps,
 # packages, and plugins designed to encourage good coding practices.
+analyzer:
+  errors:
+    avoid_print: ignore
 include: package:flutter_lints/flutter.yaml
 
 linter:

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -1,17 +1,22 @@
+// ignore_for_file: avoid_print
+
 import 'package:flutter/material.dart';
 import 'package:intl_phone_field/intl_phone_field.dart';
 
 void main() {
-  runApp(MyApp());
+  runApp(const MyApp());
 }
 
 class MyApp extends StatefulWidget {
+  const MyApp({Key? key}) : super(key: key);
+
   @override
+  // ignore: library_private_types_in_public_api
   _MyAppState createState() => _MyAppState();
 }
 
 class _MyAppState extends State<MyApp> {
-  GlobalKey<FormState> _formKey = GlobalKey();
+  final GlobalKey<FormState> _formKey = GlobalKey();
 
   FocusNode focusNode = FocusNode();
 
@@ -21,7 +26,7 @@ class _MyAppState extends State<MyApp> {
       debugShowCheckedModeBanner: false,
       home: Scaffold(
         appBar: AppBar(
-          title: Text('Phone Field Example'),
+          title: const Text('Phone Field Example'),
         ),
         body: Padding(
           padding: const EdgeInsets.symmetric(horizontal: 16.0),
@@ -30,8 +35,8 @@ class _MyAppState extends State<MyApp> {
             child: Column(
               crossAxisAlignment: CrossAxisAlignment.start,
               children: <Widget>[
-                SizedBox(height: 30),
-                TextField(
+                const SizedBox(height: 30),
+                const TextField(
                   decoration: InputDecoration(
                     labelText: 'Name',
                     border: OutlineInputBorder(
@@ -39,10 +44,10 @@ class _MyAppState extends State<MyApp> {
                     ),
                   ),
                 ),
-                SizedBox(
+                const SizedBox(
                   height: 10,
                 ),
-                TextField(
+                const TextField(
                   decoration: InputDecoration(
                     labelText: 'Email',
                     border: OutlineInputBorder(
@@ -50,12 +55,12 @@ class _MyAppState extends State<MyApp> {
                     ),
                   ),
                 ),
-                SizedBox(
+                const SizedBox(
                   height: 10,
                 ),
                 IntlPhoneField(
                   focusNode: focusNode,
-                  decoration: InputDecoration(
+                  decoration: const InputDecoration(
                     labelText: 'Phone Number',
                     border: OutlineInputBorder(
                       borderSide: BorderSide(),
@@ -66,19 +71,19 @@ class _MyAppState extends State<MyApp> {
                     print(phone.completeNumber);
                   },
                   onCountryChanged: (country) {
-                    print('Country changed to: ' + country.name);
+                    print('Country changed to: ${country.name}');
                   },
                 ),
-                SizedBox(
+                const SizedBox(
                   height: 10,
                 ),
                 MaterialButton(
-                  child: Text('Submit'),
                   color: Theme.of(context).primaryColor,
                   textColor: Colors.white,
                   onPressed: () {
                     _formKey.currentState?.validate();
                   },
+                  child: const Text('Submit'),
                 ),
               ],
             ),

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -37,10 +37,10 @@ packages:
     dependency: transitive
     description:
       name: collection
-      sha256: f092b211a4319e98e5ff58223576de6c2803db36221657b46c82574721240687
+      sha256: ee67cb0715911d28db6bf4af1026078bd6f0128b07a5f66fb2ed94ec6783c09a
       url: "https://pub.dev"
     source: hosted
-    version: "1.17.2"
+    version: "1.18.0"
   fake_async:
     dependency: transitive
     description:
@@ -65,39 +65,63 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "3.2.0"
+    version: "3.3.0"
+  leak_tracker:
+    dependency: transitive
+    description:
+      name: leak_tracker
+      sha256: "3f87a60e8c63aecc975dda1ceedbc8f24de75f09e4856ea27daf8958f2f0ce05"
+      url: "https://pub.dev"
+    source: hosted
+    version: "10.0.5"
+  leak_tracker_flutter_testing:
+    dependency: transitive
+    description:
+      name: leak_tracker_flutter_testing
+      sha256: "932549fb305594d82d7183ecd9fa93463e9914e1b67cacc34bc40906594a1806"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.0.5"
+  leak_tracker_testing:
+    dependency: transitive
+    description:
+      name: leak_tracker_testing
+      sha256: "6ba465d5d76e67ddf503e1161d1f4a6bc42306f9d66ca1e8f079a47290fb06d3"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.0.1"
   matcher:
     dependency: transitive
     description:
       name: matcher
-      sha256: "1803e76e6653768d64ed8ff2e1e67bea3ad4b923eb5c56a295c3e634bad5960e"
+      sha256: d2323aa2060500f906aa31a895b4030b6da3ebdcc5619d14ce1aada65cd161cb
       url: "https://pub.dev"
     source: hosted
-    version: "0.12.16"
+    version: "0.12.16+1"
   material_color_utilities:
     dependency: transitive
     description:
       name: material_color_utilities
-      sha256: "9528f2f296073ff54cb9fee677df673ace1218163c3bc7628093e7eed5203d41"
+      sha256: f7142bb1154231d7ea5f96bc7bde4bda2a0945d2806bb11670e30b850d56bdec
       url: "https://pub.dev"
     source: hosted
-    version: "0.5.0"
+    version: "0.11.1"
   meta:
     dependency: transitive
     description:
       name: meta
-      sha256: "3c74dbf8763d36539f114c799d8a2d87343b5067e9d796ca22b5eb8437090ee3"
+      sha256: bdb68674043280c3428e9ec998512fb681678676b3c54e773629ffe74419f8c7
       url: "https://pub.dev"
     source: hosted
-    version: "1.9.1"
+    version: "1.15.0"
   path:
     dependency: transitive
     description:
       name: path
-      sha256: "8829d8a55c13fc0e37127c29fedf290c102f4e40ae94ada574091fe0ff96c917"
+      sha256: "087ce49c3f0dc39180befefc60fdb4acd8f8620e5682fe2476afd0b3688bb4af"
       url: "https://pub.dev"
     source: hosted
-    version: "1.8.3"
+    version: "1.9.0"
   sky_engine:
     dependency: transitive
     description: flutter
@@ -115,18 +139,18 @@ packages:
     dependency: transitive
     description:
       name: stack_trace
-      sha256: c3c7d8edb15bee7f0f74debd4b9c5f3c2ea86766fe4178eb2a18eb30a0bdaed5
+      sha256: "73713990125a6d93122541237550ee3352a2d84baad52d375a4cad2eb9b7ce0b"
       url: "https://pub.dev"
     source: hosted
-    version: "1.11.0"
+    version: "1.11.1"
   stream_channel:
     dependency: transitive
     description:
       name: stream_channel
-      sha256: "83615bee9045c1d322bbbd1ba209b7a749c2cbcdcb3fdd1df8eb488b3279c1c8"
+      sha256: ba2aa5d8cc609d96bbb2899c28934f9e1af5cddbd60a827822ea467161eb54e7
       url: "https://pub.dev"
     source: hosted
-    version: "2.1.1"
+    version: "2.1.2"
   string_scanner:
     dependency: transitive
     description:
@@ -147,10 +171,10 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: "75760ffd7786fffdfb9597c35c5b27eaeec82be8edfb6d71d32651128ed7aab8"
+      sha256: "5b8a98dafc4d5c4c9c72d8b31ab2b23fc13422348d2997120294d3bac86b4ddb"
       url: "https://pub.dev"
     source: hosted
-    version: "0.6.0"
+    version: "0.7.2"
   vector_math:
     dependency: transitive
     description:
@@ -159,13 +183,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.1.4"
-  web:
+  vm_service:
     dependency: transitive
     description:
-      name: web
-      sha256: dc8ccd225a2005c1be616fe02951e2e342092edf968cf0844220383757ef8f10
+      name: vm_service
+      sha256: "5c5f338a667b4c644744b661f309fb8080bb94b18a7e91ef1dbd343bed00ed6d"
       url: "https://pub.dev"
     source: hosted
-    version: "0.1.4-beta"
+    version: "14.2.5"
 sdks:
-  dart: ">=3.1.0-185.0.dev <4.0.0"
+  dart: ">=3.3.0 <4.0.0"
+  flutter: ">=3.18.0-18.0.pre.54"

--- a/lib/countries.dart
+++ b/lib/countries.dart
@@ -1518,8 +1518,8 @@ const List<Country> countries = [
     flag: "🇨🇬",
     code: "CG",
     dialCode: "242",
-    minLength: 7,
-    maxLength: 7,
+    minLength: 9, //
+    maxLength: 9,
   ),
   Country(
     name: "Congo, The Democratic Republic of the Congo",

--- a/lib/country_picker_dialog.dart
+++ b/lib/country_picker_dialog.dart
@@ -1,7 +1,7 @@
 import 'package:flutter/foundation.dart' show kIsWeb;
 import 'package:flutter/material.dart';
-import 'package:intl_phone_field/countries.dart';
-import 'package:intl_phone_field/helpers.dart';
+import 'package:intl_field_phone/countries.dart';
+import 'package:intl_field_phone/helpers.dart';
 
 class PickerDialogStyle {
   final Color? backgroundColor;

--- a/lib/helpers.dart
+++ b/lib/helpers.dart
@@ -1,4 +1,4 @@
-import 'package:intl_phone_field/countries.dart';
+import 'package:intl_field_phone/countries.dart';
 
 bool isNumeric(String s) => s.isNotEmpty && int.tryParse(s.replaceAll("+", "")) != null;
 

--- a/lib/intl_phone_field.dart
+++ b/lib/intl_phone_field.dart
@@ -4,8 +4,8 @@ import 'dart:async';
 import 'package:flutter/foundation.dart' show kIsWeb;
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
-import 'package:intl_phone_field/country_picker_dialog.dart';
-import 'package:intl_phone_field/helpers.dart';
+import 'package:intl_field_phone/country_picker_dialog.dart';
+import 'package:intl_field_phone/helpers.dart';
 
 import './countries.dart';
 import './phone_number.dart';

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -61,10 +61,10 @@ packages:
     dependency: transitive
     description:
       name: collection
-      sha256: f092b211a4319e98e5ff58223576de6c2803db36221657b46c82574721240687
+      sha256: ee67cb0715911d28db6bf4af1026078bd6f0128b07a5f66fb2ed94ec6783c09a
       url: "https://pub.dev"
     source: hosted
-    version: "1.17.2"
+    version: "1.18.0"
   convert:
     dependency: transitive
     description:
@@ -77,10 +77,10 @@ packages:
     dependency: transitive
     description:
       name: coverage
-      sha256: "2fb815080e44a09b85e0f2ca8a820b15053982b2e714b59267719e8a9ff17097"
+      sha256: c1fb2dce3c0085f39dc72668e85f8e0210ec7de05345821ff58530567df345a5
       url: "https://pub.dev"
     source: hosted
-    version: "1.6.3"
+    version: "1.9.2"
   crypto:
     dependency: transitive
     description:
@@ -171,6 +171,30 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.6.7"
+  leak_tracker:
+    dependency: transitive
+    description:
+      name: leak_tracker
+      sha256: "3f87a60e8c63aecc975dda1ceedbc8f24de75f09e4856ea27daf8958f2f0ce05"
+      url: "https://pub.dev"
+    source: hosted
+    version: "10.0.5"
+  leak_tracker_flutter_testing:
+    dependency: transitive
+    description:
+      name: leak_tracker_flutter_testing
+      sha256: "932549fb305594d82d7183ecd9fa93463e9914e1b67cacc34bc40906594a1806"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.0.5"
+  leak_tracker_testing:
+    dependency: transitive
+    description:
+      name: leak_tracker_testing
+      sha256: "6ba465d5d76e67ddf503e1161d1f4a6bc42306f9d66ca1e8f079a47290fb06d3"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.0.1"
   lints:
     dependency: transitive
     description:
@@ -191,26 +215,26 @@ packages:
     dependency: transitive
     description:
       name: matcher
-      sha256: "1803e76e6653768d64ed8ff2e1e67bea3ad4b923eb5c56a295c3e634bad5960e"
+      sha256: d2323aa2060500f906aa31a895b4030b6da3ebdcc5619d14ce1aada65cd161cb
       url: "https://pub.dev"
     source: hosted
-    version: "0.12.16"
+    version: "0.12.16+1"
   material_color_utilities:
     dependency: transitive
     description:
       name: material_color_utilities
-      sha256: "9528f2f296073ff54cb9fee677df673ace1218163c3bc7628093e7eed5203d41"
+      sha256: f7142bb1154231d7ea5f96bc7bde4bda2a0945d2806bb11670e30b850d56bdec
       url: "https://pub.dev"
     source: hosted
-    version: "0.5.0"
+    version: "0.11.1"
   meta:
     dependency: transitive
     description:
       name: meta
-      sha256: "3c74dbf8763d36539f114c799d8a2d87343b5067e9d796ca22b5eb8437090ee3"
+      sha256: bdb68674043280c3428e9ec998512fb681678676b3c54e773629ffe74419f8c7
       url: "https://pub.dev"
     source: hosted
-    version: "1.9.1"
+    version: "1.15.0"
   mime:
     dependency: transitive
     description:
@@ -239,10 +263,10 @@ packages:
     dependency: transitive
     description:
       name: path
-      sha256: "8829d8a55c13fc0e37127c29fedf290c102f4e40ae94ada574091fe0ff96c917"
+      sha256: "087ce49c3f0dc39180befefc60fdb4acd8f8620e5682fe2476afd0b3688bb4af"
       url: "https://pub.dev"
     source: hosted
-    version: "1.8.3"
+    version: "1.9.0"
   pool:
     dependency: transitive
     description:
@@ -324,18 +348,18 @@ packages:
     dependency: transitive
     description:
       name: stack_trace
-      sha256: c3c7d8edb15bee7f0f74debd4b9c5f3c2ea86766fe4178eb2a18eb30a0bdaed5
+      sha256: "73713990125a6d93122541237550ee3352a2d84baad52d375a4cad2eb9b7ce0b"
       url: "https://pub.dev"
     source: hosted
-    version: "1.11.0"
+    version: "1.11.1"
   stream_channel:
     dependency: transitive
     description:
       name: stream_channel
-      sha256: "83615bee9045c1d322bbbd1ba209b7a749c2cbcdcb3fdd1df8eb488b3279c1c8"
+      sha256: ba2aa5d8cc609d96bbb2899c28934f9e1af5cddbd60a827822ea467161eb54e7
       url: "https://pub.dev"
     source: hosted
-    version: "2.1.1"
+    version: "2.1.2"
   string_scanner:
     dependency: transitive
     description:
@@ -356,26 +380,26 @@ packages:
     dependency: "direct dev"
     description:
       name: test
-      sha256: "13b41f318e2a5751c3169137103b60c584297353d4b1761b66029bae6411fe46"
+      sha256: "7ee44229615f8f642b68120165ae4c2a75fe77ae2065b1e55ae4711f6cf0899e"
       url: "https://pub.dev"
     source: hosted
-    version: "1.24.3"
+    version: "1.25.7"
   test_api:
     dependency: transitive
     description:
       name: test_api
-      sha256: "75760ffd7786fffdfb9597c35c5b27eaeec82be8edfb6d71d32651128ed7aab8"
+      sha256: "5b8a98dafc4d5c4c9c72d8b31ab2b23fc13422348d2997120294d3bac86b4ddb"
       url: "https://pub.dev"
     source: hosted
-    version: "0.6.0"
+    version: "0.7.2"
   test_core:
     dependency: transitive
     description:
       name: test_core
-      sha256: "99806e9e6d95c7b059b7a0fc08f07fc53fabe54a829497f0d9676299f1e8637e"
+      sha256: "55ea5a652e38a1dfb32943a7973f3681a60f872f8c3a05a14664ad54ef9c6696"
       url: "https://pub.dev"
     source: hosted
-    version: "0.5.3"
+    version: "0.6.4"
   typed_data:
     dependency: transitive
     description:
@@ -396,10 +420,10 @@ packages:
     dependency: transitive
     description:
       name: vm_service
-      sha256: ada49637c27973c183dad90beb6bd781eea4c9f5f955d35da172de0af7bd3440
+      sha256: "5c5f338a667b4c644744b661f309fb8080bb94b18a7e91ef1dbd343bed00ed6d"
       url: "https://pub.dev"
     source: hosted
-    version: "11.8.0"
+    version: "14.2.5"
   watcher:
     dependency: transitive
     description:
@@ -408,14 +432,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.1.0"
-  web:
-    dependency: transitive
-    description:
-      name: web
-      sha256: dc8ccd225a2005c1be616fe02951e2e342092edf968cf0844220383757ef8f10
-      url: "https://pub.dev"
-    source: hosted
-    version: "0.1.4-beta"
   web_socket_channel:
     dependency: transitive
     description:
@@ -441,4 +457,5 @@ packages:
     source: hosted
     version: "3.1.2"
 sdks:
-  dart: ">=3.1.0-185.0.dev <4.0.0"
+  dart: ">=3.4.0 <4.0.0"
+  flutter: ">=3.18.0-18.0.pre.54"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
-name: intl_phone_field
+name: intl_field_phone
 description: A customised Flutter TextFormField to input international phone number along with country code.
-version: 3.3.0
+version: 3.3.1
 homepage: https://github.com/vanshg395/intl_phone_field
 
 environment:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,8 @@
 name: intl_field_phone
 description: A customised Flutter TextFormField to input international phone number along with country code.
 version: 3.3.1
-homepage: https://github.com/vanshg395/intl_phone_field
+homepage: https://github.com/Batutankuma/intl_phone_field
+repository: https://github.com/Batutankuma/intl_phone_field
 
 environment:
   sdk: ">=2.12.0 <3.0.0"

--- a/test/intl_phone_field_test.dart
+++ b/test/intl_phone_field_test.dart
@@ -1,6 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
-import 'package:intl_phone_field/intl_phone_field.dart';
+import 'package:intl_field_phone/intl_phone_field.dart';
 
 class TestWidget extends StatelessWidget {
   const TestWidget({Key? key, required this.phoneNumber, this.countryCode}) : super(key: key);

--- a/test/phonenumber_test.dart
+++ b/test/phonenumber_test.dart
@@ -6,9 +6,9 @@
 // tree, read text, and verify that the values of widget properties are correct.
 
 //import 'package:flutter_test/flutter_test.dart';
-import 'package:intl_phone_field/countries.dart';
+import 'package:intl_field_phone/countries.dart';
 import 'package:test/test.dart';
-import 'package:intl_phone_field/phone_number.dart';
+import 'package:intl_field_phone/phone_number.dart';
 
 void main() {
   group('PhoneNumber', () {

--- a/test/phonenumber_test.dart
+++ b/test/phonenumber_test.dart
@@ -32,6 +32,7 @@ void main() {
 
     test('look up UK as a country code', () {
       Country country = PhoneNumber.getCountry("+447891234567");
+      print(country.name);
       expect(country.name, "United Kingdom");
       expect(country.code, "GB");
       expect(country.regionCode, "");
@@ -76,6 +77,15 @@ void main() {
       expect(phoneNumber.countryISOCode, "GB");
       expect(phoneNumber.countryCode, "44");
       expect(phoneNumber.number, "7891234567");
+      expect(phoneNumber.isValidNumber(), true);
+    });
+
+    //Add test
+    test('create CG PhoneNumber from +242057009244', () {
+      PhoneNumber phoneNumber = PhoneNumber.fromCompleteNumber(completeNumber: "+242057009244");
+      expect(phoneNumber.countryISOCode, "CG");
+      expect(phoneNumber.countryCode, "242");
+      expect(phoneNumber.number, "057009244");
       expect(phoneNumber.isValidNumber(), true);
     });
 

--- a/test/phonenumber_test.dart
+++ b/test/phonenumber_test.dart
@@ -13,9 +13,9 @@ import 'package:intl_phone_field/phone_number.dart';
 void main() {
   group('PhoneNumber', () {
     test('create a phone number', () {
-      PhoneNumber phoneNumber = PhoneNumber(countryISOCode: "UK", countryCode: "+44", number: "7891234567");
+      PhoneNumber phoneNumber = PhoneNumber(countryISOCode: "CD", countryCode: "+243", number: "812167999");
       String actual = phoneNumber.completeNumber;
-      String expected = "+447891234567";
+      String expected = "+243812167999";
 
       expect(actual, expected);
       expect(phoneNumber.isValidNumber(), true);
@@ -30,19 +30,12 @@ void main() {
       expect(phoneNumber.isValidNumber(), true);
     });
 
-    test('look up UK as a country code', () {
-      Country country = PhoneNumber.getCountry("+447891234567");
-      print(country.name);
-      expect(country.name, "United Kingdom");
-      expect(country.code, "GB");
+    test('look up CD as a country code', () {
+      Country country = PhoneNumber.getCountry("+243812167999");
+      print(country.code);
+      expect(country.name, "Congo, The Democratic Republic of the Congo");
+      expect(country.code, "CD");
       expect(country.regionCode, "");
-    });
-
-    test('look up Guernsey as a country code', () {
-      Country country = PhoneNumber.getCountry("+441481960194");
-      expect(country.name, "Guernsey");
-      expect(country.code, "GG");
-      expect(country.regionCode, "1481");
     });
 
     test('create with empty complete number', () {
@@ -72,11 +65,11 @@ void main() {
       expect(() => ph.isValidNumber(), throwsA(const TypeMatcher<NumberTooLongException>()));
     });
 
-    test('create UK PhoneNumber from +447891234567', () {
-      PhoneNumber phoneNumber = PhoneNumber.fromCompleteNumber(completeNumber: "+447891234567");
-      expect(phoneNumber.countryISOCode, "GB");
-      expect(phoneNumber.countryCode, "44");
-      expect(phoneNumber.number, "7891234567");
+    test('create CD PhoneNumber from +243812167999', () {
+      PhoneNumber phoneNumber = PhoneNumber.fromCompleteNumber(completeNumber: "+243812167999");
+      expect(phoneNumber.countryISOCode, "CD");
+      expect(phoneNumber.countryCode, "243");
+      expect(phoneNumber.number, "812167999");
       expect(phoneNumber.isValidNumber(), true);
     });
 
@@ -86,14 +79,6 @@ void main() {
       expect(phoneNumber.countryISOCode, "CG");
       expect(phoneNumber.countryCode, "242");
       expect(phoneNumber.number, "057009244");
-      expect(phoneNumber.isValidNumber(), true);
-    });
-
-    test('create Guernsey PhoneNumber from +441481960194', () {
-      PhoneNumber phoneNumber = PhoneNumber.fromCompleteNumber(completeNumber: "+441481960194");
-      expect(phoneNumber.countryISOCode, "GG");
-      expect(phoneNumber.countryCode, "441481");
-      expect(phoneNumber.number, "960194");
       expect(phoneNumber.isValidNumber(), true);
     });
 

--- a/test/phonenumber_test.dart
+++ b/test/phonenumber_test.dart
@@ -32,7 +32,6 @@ void main() {
 
     test('look up CD as a country code', () {
       Country country = PhoneNumber.getCountry("+243812167999");
-      print(country.code);
       expect(country.name, "Congo, The Democratic Republic of the Congo");
       expect(country.code, "CD");
       expect(country.regionCode, "");


### PR DESCRIPTION
I encountered an issue when trying to register a Congo-Brazzaville phone number in the input number field. The length after the country code was set to 7 characters, but phone numbers in Congo-Brazzaville should have 9 characters after the country code, similar to the Democratic Republic of Congo (DRC), which is my country of origin.

Example of the issue:

Incorrect: +242 1234567
Correct: +242 123456789
To fix this, I updated the length in the country.dart file for Congo-Brazzaville:

`Country(
  name: "Congo",
  nameTranslations: {
    "sk": "Konžská republika",
    "se": "Kongo-Brazzaville",
    "pl": "Kongo",
    "no": "Kongo-Brazzaville",
    "ja": "コンゴ共和国(ブラザビル)",
    "it": "Congo-Brazzaville",
    "zh": "刚果（布）",
    "nl": "Congo-Brazzaville",
    "de": "Kongo-Brazzaville",
    "fr": "Congo-Brazzaville",
    "es": "Congo",
    "en": "Congo - Brazzaville",
    "pt_BR": "República do Congo",
    "sr-Cyrl": "Република Конго",
    "sr-Latn": "Republika Kongo",
    "zh_TW": "剛果共和國（布拉柴維爾）",
    "tr": "Kongo Cumhuriyeti",
    "ro": "Republica Congo",
    "ar": "جمهورية الكونغو",
    "fa": "جمهوری کنگو",
    "yue": "剛果（共和國）"
  },
  flag: "🇨🇬",
  code: "CG",
  dialCode: "242",
  minLength: 9, // updated
  maxLength: 9, // updated
),
`
I also wrote a test to confirm the changes work correctly:
`test('create CG PhoneNumber from +242057009244', () {
  PhoneNumber phoneNumber = PhoneNumber.fromCompleteNumber(completeNumber: "+242057009244");
  expect(phoneNumber.countryISOCode, "CG");
  expect(phoneNumber.countryCode, "242");
  expect(phoneNumber.number, "057009244");
  expect(phoneNumber.isValidNumber(), true);
});
`