### PR TITLE
feat: add optional flagSize parameter to customize country flag size

### DIFF
--- a/lib/country_picker_dialog.dart
+++ b/lib/country_picker_dialog.dart
@@ -46,6 +46,7 @@ class CountryPickerDialog extends StatefulWidget {
   final List<Country> filteredCountries;
   final PickerDialogStyle? style;
   final String languageCode;
+  final double flagSize;
 
   const CountryPickerDialog({
     Key? key,
@@ -55,6 +56,7 @@ class CountryPickerDialog extends StatefulWidget {
     required this.onCountryChanged,
     required this.selectedCountry,
     required this.filteredCountries,
+    required this.flagSize,
     this.style,
   }) : super(key: key);
 
@@ -124,11 +126,11 @@ class _CountryPickerDialogState extends State<CountryPickerDialog> {
                           ? Image.asset(
                               'assets/flags/${_filteredCountries[index].code.toLowerCase()}.png',
                               package: 'intl_phone_field',
-                              width: 32,
+                              width: widget.flagSize,
                             )
                           : Text(
                               _filteredCountries[index].flag,
-                              style: const TextStyle(fontSize: 18),
+                              style: TextStyle(fontSize: widget.flagSize),
                             ),
                       contentPadding: widget.style?.listTilePadding,
                       title: Text(

--- a/lib/intl_phone_field.dart
+++ b/lib/intl_phone_field.dart
@@ -1,6 +1,7 @@
 library intl_phone_field;
 
 import 'dart:async';
+
 import 'package:flutter/foundation.dart' show kIsWeb;
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
@@ -249,54 +250,63 @@ class IntlPhoneField extends StatefulWidget {
   /// If null, default magnification configuration will be used.
   final TextMagnifierConfiguration? magnifierConfiguration;
 
-  const IntlPhoneField({
-    Key? key,
-    this.formFieldKey,
-    this.initialCountryCode,
-    this.languageCode = 'en',
-    this.disableAutoFillHints = false,
-    this.obscureText = false,
-    this.textAlign = TextAlign.left,
-    this.textAlignVertical,
-    this.onTap,
-    this.readOnly = false,
-    this.initialValue,
-    this.keyboardType = TextInputType.phone,
-    this.controller,
-    this.focusNode,
-    this.decoration = const InputDecoration(),
-    this.style,
-    this.dropdownTextStyle,
-    this.onSubmitted,
-    this.validator,
-    this.onChanged,
-    this.countries,
-    this.onCountryChanged,
-    this.onSaved,
-    this.showDropdownIcon = true,
-    this.dropdownDecoration = const BoxDecoration(),
-    this.inputFormatters,
-    this.enabled = true,
-    this.keyboardAppearance,
-    @Deprecated('Use searchFieldInputDecoration of PickerDialogStyle instead') this.searchText = 'Search country',
-    this.dropdownIconPosition = IconPosition.leading,
-    this.dropdownIcon = const Icon(Icons.arrow_drop_down),
-    this.autofocus = false,
-    this.textInputAction,
-    this.autovalidateMode = AutovalidateMode.onUserInteraction,
-    this.showCountryFlag = true,
-    this.cursorColor,
-    this.disableLengthCheck = false,
-    this.flagsButtonPadding = EdgeInsets.zero,
-    this.invalidNumberMessage = 'Invalid Mobile Number',
-    this.cursorHeight,
-    this.cursorRadius = Radius.zero,
-    this.cursorWidth = 2.0,
-    this.showCursor = true,
-    this.pickerDialogStyle,
-    this.flagsButtonMargin = EdgeInsets.zero,
-    this.magnifierConfiguration,
-  }) : super(key: key);
+  /// Size of the country flag.
+  ///
+  /// On web, this controls the image width.
+  /// On mobile, this controls the emoji font size.
+  ///
+  /// Defaults to 32.0 on web and 18.0 on mobile.
+  final double? flagSize;
+
+  const IntlPhoneField(
+      {Key? key,
+      this.formFieldKey,
+      this.initialCountryCode,
+      this.languageCode = 'en',
+      this.disableAutoFillHints = false,
+      this.obscureText = false,
+      this.textAlign = TextAlign.left,
+      this.textAlignVertical,
+      this.onTap,
+      this.readOnly = false,
+      this.initialValue,
+      this.keyboardType = TextInputType.phone,
+      this.controller,
+      this.focusNode,
+      this.decoration = const InputDecoration(),
+      this.style,
+      this.dropdownTextStyle,
+      this.onSubmitted,
+      this.validator,
+      this.onChanged,
+      this.countries,
+      this.onCountryChanged,
+      this.onSaved,
+      this.showDropdownIcon = true,
+      this.dropdownDecoration = const BoxDecoration(),
+      this.inputFormatters,
+      this.enabled = true,
+      this.keyboardAppearance,
+      @Deprecated('Use searchFieldInputDecoration of PickerDialogStyle instead') this.searchText = 'Search country',
+      this.dropdownIconPosition = IconPosition.leading,
+      this.dropdownIcon = const Icon(Icons.arrow_drop_down),
+      this.autofocus = false,
+      this.textInputAction,
+      this.autovalidateMode = AutovalidateMode.onUserInteraction,
+      this.showCountryFlag = true,
+      this.cursorColor,
+      this.disableLengthCheck = false,
+      this.flagsButtonPadding = EdgeInsets.zero,
+      this.invalidNumberMessage = 'Invalid Mobile Number',
+      this.cursorHeight,
+      this.cursorRadius = Radius.zero,
+      this.cursorWidth = 2.0,
+      this.showCursor = true,
+      this.pickerDialogStyle,
+      this.flagsButtonMargin = EdgeInsets.zero,
+      this.magnifierConfiguration,
+      this.flagSize})
+      : super(key: key);
 
   @override
   State<IntlPhoneField> createState() => _IntlPhoneFieldState();
@@ -448,6 +458,7 @@ class _IntlPhoneFieldState extends State<IntlPhoneField> {
   }
 
   Container _buildFlagsButton() {
+    final double effectiveFlagSize = widget.flagSize ?? (kIsWeb ? 32.0 : 18.0);
     return Container(
       margin: widget.flagsButtonMargin,
       child: DecoratedBox(
@@ -475,11 +486,11 @@ class _IntlPhoneFieldState extends State<IntlPhoneField> {
                       ? Image.asset(
                           'assets/flags/${_selectedCountry.code.toLowerCase()}.png',
                           package: 'intl_phone_field',
-                          width: 32,
+                          width: effectiveFlagSize,
                         )
                       : Text(
                           _selectedCountry.flag,
-                          style: const TextStyle(fontSize: 18),
+                          style: TextStyle(fontSize: effectiveFlagSize),
                         ),
                   const SizedBox(width: 8),
                 ],

--- a/lib/intl_phone_field.dart
+++ b/lib/intl_phone_field.dart
@@ -365,25 +365,25 @@ class _IntlPhoneFieldState extends State<IntlPhoneField> {
     }
   }
 
-  Future<void> _changeCountry() async {
+  Future<void> _changeCountry({required double flagSize}) async {
     filteredCountries = _countryList;
     await showDialog(
       context: context,
       useRootNavigator: false,
       builder: (context) => StatefulBuilder(
         builder: (ctx, setState) => CountryPickerDialog(
-          languageCode: widget.languageCode.toLowerCase(),
-          style: widget.pickerDialogStyle,
-          filteredCountries: filteredCountries,
-          searchText: widget.searchText,
-          countryList: _countryList,
-          selectedCountry: _selectedCountry,
-          onCountryChanged: (Country country) {
-            _selectedCountry = country;
-            widget.onCountryChanged?.call(country);
-            setState(() {});
-          },
-        ),
+            languageCode: widget.languageCode.toLowerCase(),
+            style: widget.pickerDialogStyle,
+            filteredCountries: filteredCountries,
+            searchText: widget.searchText,
+            countryList: _countryList,
+            selectedCountry: _selectedCountry,
+            onCountryChanged: (Country country) {
+              _selectedCountry = country;
+              widget.onCountryChanged?.call(country);
+              setState(() {});
+            },
+            flagSize: flagSize),
       ),
     );
     if (mounted) setState(() {});
@@ -465,7 +465,7 @@ class _IntlPhoneFieldState extends State<IntlPhoneField> {
         decoration: widget.dropdownDecoration,
         child: InkWell(
           borderRadius: widget.dropdownDecoration.borderRadius as BorderRadius?,
-          onTap: widget.enabled ? _changeCountry : null,
+          onTap: widget.enabled ? () => _changeCountry(flagSize: effectiveFlagSize) : null,
           child: Padding(
             padding: widget.flagsButtonPadding,
             child: Row(


### PR DESCRIPTION
Closes #446 

Adds an optional `flagSize` parameter to allow customizing
the country flag size.

- Default behavior unchanged (32.0 web, 18.0 mobile)
- Fully backward compatible
- No breaking changes

Happy to adjust based on feedback.