### PR TITLE
Update argentina min and max length

### DIFF
--- a/lib/countries.dart
+++ b/lib/countries.dart
@@ -340,8 +340,8 @@ const List<Country> countries = [
     flag: "🇦🇷",
     code: "AR",
     dialCode: "54",
-    minLength: 12,
-    maxLength: 12,
+    minLength: 11,
+    maxLength: 13,
   ),
   Country(
     name: "Armenia",


### PR DESCRIPTION
Local Argentinian numbers (without +54) are usually 10 digits.

International format (with +54) can be 11 or 12 digits (not counting the “+”), depending on whether it’s landline or mobile.